### PR TITLE
feat: bootstrap portal web shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+out
+.DS_Store
+.env
+.env.local

--- a/apps/portal-web/.env.example
+++ b/apps/portal-web/.env.example
@@ -1,0 +1,2 @@
+NEXTAUTH_SECRET=your-generated-secret
+NEXTAUTH_URL=http://localhost:3000

--- a/apps/portal-web/.eslintrc.json
+++ b/apps/portal-web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next", "next/core-web-vitals"]
+}

--- a/apps/portal-web/app/api/auth/[...nextauth]/route.ts
+++ b/apps/portal-web/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/apps/portal-web/app/exports/page.tsx
+++ b/apps/portal-web/app/exports/page.tsx
@@ -1,0 +1,62 @@
+const exportsList = [
+  {
+    name: "Board summary.pdf",
+    frequency: "Weekly",
+    lastRun: "Today 07:00",
+    status: "Delivered"
+  },
+  {
+    name: "Policy compliance.csv",
+    frequency: "Daily",
+    lastRun: "Today 05:15",
+    status: "Delivered"
+  },
+  {
+    name: "Dealer allocation.xlsx",
+    frequency: "Monthly",
+    lastRun: "Sep 30",
+    status: "Queued"
+  }
+];
+
+export default function ExportsPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-10">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold text-foreground">Exports &amp; reporting</h1>
+        <p className="text-sm text-foreground/70">
+          Configure always-fresh packets across PDF, CSV, and XLS to keep stakeholders in the loop.
+        </p>
+      </div>
+      <div className="overflow-hidden rounded-3xl border border-white/10 bg-white/5">
+        <table className="min-w-full divide-y divide-white/10 text-left text-sm">
+          <thead className="bg-white/5 text-xs uppercase tracking-wider text-foreground/60">
+            <tr>
+              <th className="px-6 py-4">Name</th>
+              <th className="px-6 py-4">Cadence</th>
+              <th className="px-6 py-4">Last run</th>
+              <th className="px-6 py-4">Status</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-white/10 text-foreground/80">
+            {exportsList.map((item) => (
+              <tr key={item.name} className="hover:bg-white/5">
+                <td className="px-6 py-4 font-semibold text-foreground">{item.name}</td>
+                <td className="px-6 py-4">{item.frequency}</td>
+                <td className="px-6 py-4">{item.lastRun}</td>
+                <td className="px-6 py-4">
+                  <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-300">
+                    {item.status}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="rounded-3xl border border-dashed border-white/20 bg-white/5 p-6 text-sm text-foreground/70">
+        Need to push data into your warehouse? Portal exposes streaming webhooks alongside daily file drops.
+      </div>
+    </div>
+  );
+}

--- a/apps/portal-web/app/exposures/page.tsx
+++ b/apps/portal-web/app/exposures/page.tsx
@@ -1,0 +1,58 @@
+import { ExposureTable, type Exposure } from "@/components/ui/exposure-table";
+
+const data: Exposure[] = [
+  {
+    currencyPair: "USD/JPY",
+    netExposure: "¥620M",
+    hedged: "78%",
+    status: "warning",
+    updatedAt: "2m ago"
+  },
+  {
+    currencyPair: "EUR/GBP",
+    netExposure: "£42M",
+    hedged: "92%",
+    status: "covered",
+    updatedAt: "5m ago"
+  },
+  {
+    currencyPair: "AUD/USD",
+    netExposure: "$18M",
+    hedged: "61%",
+    status: "critical",
+    updatedAt: "30s ago"
+  },
+  {
+    currencyPair: "USD/BRL",
+    netExposure: "R$75M",
+    hedged: "84%",
+    status: "warning",
+    updatedAt: "11m ago"
+  }
+];
+
+const insightTiles = [
+  { label: "Net cashflow drift", value: "12.4%" },
+  { label: "Sensitivity to USD", value: "68.0%" },
+  { label: "Policy breaches", value: "2 flags" }
+];
+
+export default function ExposuresPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-10">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold text-foreground">Exposure overview</h1>
+        <p className="text-sm text-foreground/70">Monitor program coverage and identify material FX swings in real time.</p>
+      </div>
+      <ExposureTable rows={data} />
+      <div className="grid gap-6 sm:grid-cols-3">
+        {insightTiles.map((metric) => (
+          <div key={metric.label} className="rounded-3xl border border-white/10 bg-white/5 p-6">
+            <p className="text-xs uppercase tracking-widest text-foreground/50">{metric.label}</p>
+            <p className="mt-3 text-2xl font-semibold text-foreground">{metric.value}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/portal-web/app/globals.css
+++ b/apps/portal-web/app/globals.css
@@ -1,0 +1,29 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+@layer base {
+  body {
+    @apply bg-background text-foreground font-sans min-h-screen;
+    background-image: radial-gradient(circle at 20% 20%, rgba(124, 92, 255, 0.25), transparent 55%),
+      radial-gradient(circle at 80% 0%, rgba(67, 56, 202, 0.35), transparent 60%);
+    background-color: #05070d;
+  }
+
+  a {
+    @apply text-foreground;
+  }
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}

--- a/apps/portal-web/app/hedges/page.tsx
+++ b/apps/portal-web/app/hedges/page.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link";
+import { HedgeCard } from "@/components/ui/hedge-card";
+
+const hedges = [
+  {
+    title: "Quarterly USD program",
+    subtitle: "Rolling 3-month ladder hedging against forecasted EUR cashflows.",
+    metrics: [
+      { label: "Coverage", value: "85%", helper: "Policy target: 80-95%" },
+      { label: "VaR impact", value: "-12%" },
+      { label: "Next action", value: "Nov 14" }
+    ]
+  },
+  {
+    title: "LatAm risk sleeve",
+    subtitle: "Dynamic hedging with max slippage enforcement across BRL and MXN.",
+    metrics: [
+      { label: "Coverage", value: "68%", helper: "Trigger at 65%" },
+      { label: "Drift vs plan", value: "+4%" },
+      { label: "Alerts", value: "2 open" }
+    ]
+  }
+];
+
+export default function HedgesPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-10">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold text-foreground">Hedge playbooks</h1>
+        <p className="text-sm text-foreground/70">
+          Activate and monitor hedge strategies with clear guardrails and escalation rules.
+        </p>
+      </div>
+      <div className="grid gap-6">
+        {hedges.map((hedge) => (
+          <HedgeCard
+            key={hedge.title}
+            title={hedge.title}
+            subtitle={hedge.subtitle}
+            metrics={hedge.metrics}
+            action={
+              <Link
+                href="#"
+                className="inline-flex items-center gap-2 text-sm font-semibold text-accent hover:text-accent/80"
+              >
+                View runbook →
+              </Link>
+            }
+          />
+        ))}
+      </div>
+      <div className="rounded-3xl border border-dashed border-accent/40 bg-accent/5 p-6 text-center text-sm text-foreground/60">
+        Need another playbook? Drag in hedging widgets from the library to construct new guardrails in minutes.
+      </div>
+    </div>
+  );
+}

--- a/apps/portal-web/app/layout.tsx
+++ b/apps/portal-web/app/layout.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import { ReactNode } from "react";
+import { Navbar } from "@/components/layout/navbar";
+import { SessionProvider } from "@/components/providers/session-provider";
+
+export const metadata: Metadata = {
+  title: "FX Portal",
+  description: "Modern hedging & exposure management portal"
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" className="dark">
+      <body className="bg-background text-foreground">
+        <SessionProvider>
+          <div className="relative flex min-h-screen flex-col">
+            <Navbar />
+            <main className="flex-1 px-4 pb-16 pt-24 sm:px-8 lg:px-16 xl:px-24">
+              {children}
+            </main>
+            <footer className="px-4 py-8 text-center text-xs text-foreground/60 sm:px-8">
+              © {new Date().getFullYear()} FX Portal. All rights reserved.
+            </footer>
+          </div>
+        </SessionProvider>
+      </body>
+    </html>
+  );
+}

--- a/apps/portal-web/app/page.tsx
+++ b/apps/portal-web/app/page.tsx
@@ -1,0 +1,173 @@
+const partners = [
+  "Aurora Bank",
+  "Northwind FX",
+  "Velocity Markets",
+  "Polaris Capital",
+  "Atlas Treasury"
+];
+
+const kpis = [
+  { label: "Coverage automated", value: "92%" },
+  { label: "Average spread saved", value: "18 bps" },
+  { label: "Time to hedge", value: "<4 min" }
+];
+
+const features = [
+  {
+    title: "Exposure clarity",
+    description:
+      "Bring every currency cashflow into a single adaptive view with AI assisted tagging and materiality scoring.",
+    icon: "📊"
+  },
+  {
+    title: "Dealer collaboration",
+    description:
+      "Orchestrate RFQs, compare quotes, and trigger programmatic hedges while maintaining full auditability.",
+    icon: "🤝"
+  },
+  {
+    title: "Automated policies",
+    description:
+      "Codify hedge ratios, stop-loss rules, and escalation paths that keep governance satisfied without slowing you down.",
+    icon: "⚙️"
+  }
+];
+
+const livePairs = [
+  { pair: "USD/JPY", cadence: "Program hedge cadence", velocity: "1.32x" },
+  { pair: "EUR/GBP", cadence: "Program hedge cadence", velocity: "0.87x" },
+  { pair: "AUD/USD", cadence: "Event-driven coverage", velocity: "1.08x" },
+  { pair: "USD/BRL", cadence: "Dynamic tolerance bands", velocity: "1.54x" }
+];
+
+export default function HomePage() {
+  return (
+    <div className="mx-auto flex w-full max-w-7xl flex-col gap-24">
+      <section className="relative isolate overflow-hidden rounded-3xl border border-white/10 bg-white/5 px-8 py-16 shadow-soft sm:px-12 lg:px-16">
+        <div className="absolute inset-0 -z-10 bg-grid-light [background-size:30px_30px] opacity-20" />
+        <div className="flex flex-col gap-12 lg:flex-row lg:items-center">
+          <div className="flex-1 space-y-8">
+            <div className="inline-flex items-center gap-3 rounded-full border border-accent/40 bg-accent/10 px-4 py-2 text-sm text-accent">
+              <span className="inline-flex h-2 w-2 rounded-full bg-accent" />
+              Treasury teams ship faster with FX Portal
+            </div>
+            <div className="space-y-6">
+              <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl lg:text-6xl">
+                Precision hedging designed for modern treasury desks.
+              </h1>
+              <p className="max-w-xl text-lg text-foreground/70">
+                Capture exposures in real time, simulate hedge strategies, and execute with confidence using a single
+                collaborative workspace purpose built for FX risk owners.
+              </p>
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <button className="rounded-full bg-accent px-6 py-3 text-sm font-semibold text-white shadow-soft transition hover:translate-y-0.5">
+                Request access
+              </button>
+              <button className="rounded-full border border-white/20 px-6 py-3 text-sm font-semibold text-foreground/80 transition hover:border-accent hover:text-foreground">
+                Explore product tour
+              </button>
+            </div>
+            <dl className="grid grid-cols-1 gap-6 sm:grid-cols-3">
+              {kpis.map((kpi) => (
+                <div key={kpi.label} className="rounded-2xl bg-black/20 p-4">
+                  <dt className="text-xs uppercase tracking-widest text-foreground/50">{kpi.label}</dt>
+                  <dd className="mt-2 text-2xl font-semibold text-foreground">{kpi.value}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+          <div className="flex-1">
+            <div className="relative mx-auto max-w-md rounded-[2.5rem] border border-white/10 bg-black/40 p-6 shadow-soft">
+              <div className="flex items-center justify-between text-xs text-foreground/60">
+                <span>Live exposures</span>
+                <span>Last sync • 28s ago</span>
+              </div>
+              <div className="mt-6 space-y-4">
+                {livePairs.map((item) => (
+                  <div key={item.pair} className="flex items-center justify-between rounded-2xl bg-white/5 px-4 py-3">
+                    <div>
+                      <p className="text-sm font-semibold text-foreground">{item.pair}</p>
+                      <p className="text-xs text-foreground/50">{item.cadence}</p>
+                    </div>
+                    <span className="text-sm font-semibold text-emerald-300">{item.velocity}</span>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-6 rounded-2xl bg-gradient-to-br from-accent/20 via-accent/10 to-transparent p-4 text-sm text-foreground/70">
+                AI assistant is monitoring drift and will alert when hedge window opens.
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="mt-16 space-y-6" id="company">
+          <p className="text-xs uppercase tracking-[0.3em] text-foreground/50">Trusted by innovative treasury teams</p>
+          <div className="grid grid-cols-2 gap-6 text-sm text-foreground/60 sm:grid-cols-3 md:grid-cols-5">
+            {partners.map((partner) => (
+              <div key={partner} className="rounded-full border border-white/10 bg-white/5 px-4 py-2 text-center">
+                {partner}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-12" id="features">
+        <div className="max-w-3xl space-y-4">
+          <p className="text-sm uppercase tracking-[0.4em] text-foreground/50">Workflow toolkit</p>
+          <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">Everything a currency program needs in one shell.</h2>
+          <p className="text-base text-foreground/70">
+            Connect exposures, hedge mandates, and execution venues into a single programmable platform. Ready out of the box
+            with API access and enterprise controls.
+          </p>
+        </div>
+        <div className="grid gap-8 lg:grid-cols-3">
+          {features.map((feature) => (
+            <div key={feature.title} className="flex flex-col gap-4 rounded-3xl border border-white/10 bg-white/5 p-6">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-accent/20 text-2xl">
+                <span aria-hidden="true">{feature.icon}</span>
+              </div>
+              <h3 className="text-xl font-semibold text-foreground">{feature.title}</h3>
+              <p className="text-sm text-foreground/60">{feature.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-12 lg:grid-cols-[1.2fr_1fr]" id="about">
+        <div className="space-y-6">
+          <h2 className="text-3xl font-semibold text-foreground">A shell that adapts to your program.</h2>
+          <p className="text-base text-foreground/70">
+            Modular widgets let you tailor the portal experience across exposures, quotes, hedge playbooks, and reporting. Dark theme is tuned for the late-night desks monitoring global cycles.
+          </p>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
+              <h3 className="text-lg font-semibold text-foreground">Composable analytics</h3>
+              <p className="mt-2 text-sm text-foreground/60">
+                Drag charts, sensitivity tiles, and forward curves into custom dashboards that export instantly.
+              </p>
+            </div>
+            <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
+              <h3 className="text-lg font-semibold text-foreground">Policy alignment</h3>
+              <p className="mt-2 text-sm text-foreground/60">
+                Encode limits and approvals once; reuse across exposures, hedges, and treasury playbooks.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div className="rounded-[2.5rem] border border-white/10 bg-gradient-to-br from-white/10 via-black/20 to-transparent p-8">
+          <h3 className="text-xl font-semibold text-foreground">Launch readiness</h3>
+          <ul className="mt-6 space-y-4 text-sm text-foreground/70">
+            <li>✔ Integrate via REST or SFTP connectors</li>
+            <li>✔ SOC2 &amp; GDPR controls baked-in</li>
+            <li>✔ Single-sign-on ready</li>
+            <li>✔ 24/5 follow-the-sun support</li>
+          </ul>
+          <div className="mt-8 rounded-2xl bg-accent/20 p-4 text-sm text-accent">
+            "Within weeks we went from spreadsheet chaos to an orchestrated hedging rhythm." — Placeholder CFO quote
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/portal-web/app/quotes/page.tsx
+++ b/apps/portal-web/app/quotes/page.tsx
@@ -1,0 +1,32 @@
+import { QuoteSliderCard } from "@/components/ui/quote-slider-card";
+
+const quotes = [
+  { dealer: "Aurora Bank", currencyPair: "USD/JPY", midRate: 148.32, spreadBps: 12 },
+  { dealer: "Velocity Markets", currencyPair: "EUR/GBP", midRate: 0.8675, spreadBps: 9 },
+  { dealer: "Polaris Capital", currencyPair: "AUD/USD", midRate: 0.6432, spreadBps: 15 }
+];
+
+export default function QuotesPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-10">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold text-foreground">Live RFQs</h1>
+        <p className="text-sm text-foreground/70">
+          Simulate hedge ratios against dealer spreads and capture the best-fit execution without leaving the workspace.
+        </p>
+      </div>
+      <div className="grid gap-6 md:grid-cols-2">
+        {quotes.map((quote) => (
+          <QuoteSliderCard key={quote.dealer} {...quote} />
+        ))}
+      </div>
+      <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
+        <h2 className="text-xl font-semibold text-foreground">Auto-execution window</h2>
+        <p className="mt-2 text-sm text-foreground/70">
+          Program the spread tolerance, size tiers, and allocation logic, then let Portal manage the orchestration with your
+          counterparties.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/portal-web/app/settings/page.tsx
+++ b/apps/portal-web/app/settings/page.tsx
@@ -1,0 +1,52 @@
+const toggles = [
+  { label: "Enable SSO enforcement", description: "Require SAML SSO for all workspace members", enabled: true },
+  {
+    label: "Auto-approve dealer quotes",
+    description: "Allow spreads under policy threshold to auto execute",
+    enabled: false
+  },
+  {
+    label: "Nightly exposure digest",
+    description: "Send condensed summary to leadership distribution list",
+    enabled: true
+  }
+];
+
+export default function SettingsPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-10">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold text-foreground">Workspace settings</h1>
+        <p className="text-sm text-foreground/70">Configure authentication, automations, and communications.</p>
+      </div>
+      <div className="space-y-4">
+        {toggles.map((item) => (
+          <label
+            key={item.label}
+            className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:border-accent/40"
+          >
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-semibold text-foreground">{item.label}</p>
+                <p className="text-xs text-foreground/60">{item.description}</p>
+              </div>
+              <span
+                className={`inline-flex h-6 w-12 items-center rounded-full border border-white/10 bg-black/40 px-1 ${
+                  item.enabled ? "justify-end" : "justify-start"
+                }`}
+              >
+                <span className={`h-4 w-4 rounded-full ${item.enabled ? "bg-accent" : "bg-white/30"}`} />
+              </span>
+            </div>
+            <span className="text-[11px] uppercase tracking-[0.3em] text-foreground/40">
+              {item.enabled ? "Active" : "Paused"}
+            </span>
+          </label>
+        ))}
+      </div>
+      <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-foreground/70">
+        Need deeper controls? Extend Portal via API tokens to sync approvals from your internal systems.
+      </div>
+    </div>
+  );
+}

--- a/apps/portal-web/components/layout/navbar.tsx
+++ b/apps/portal-web/components/layout/navbar.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { signIn, signOut, useSession } from "next-auth/react";
+import { useMemo } from "react";
+
+const links = [
+  { href: "/", label: "Home" },
+  { href: "#features", label: "Features" },
+  { href: "#company", label: "Company" },
+  { href: "#about", label: "About Us" }
+];
+
+export function Navbar() {
+  const pathname = usePathname();
+  const { data: session } = useSession();
+
+  const linkElements = useMemo(
+    () =>
+      links.map((link) => {
+        const isActive = link.href !== "#" && pathname === link.href;
+        return (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={`text-sm font-medium transition hover:text-foreground ${
+              isActive ? "text-foreground" : "text-foreground/70"
+            }`}
+          >
+            {link.label}
+          </Link>
+        );
+      }),
+    [pathname]
+  );
+
+  return (
+    <header className="fixed inset-x-0 top-0 z-50 backdrop-blur">
+      <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 border-b border-white/5 bg-background/80 px-4 py-4 sm:px-8">
+        <Link href="/" className="text-lg font-semibold">
+          FX Portal
+        </Link>
+        <nav className="hidden items-center gap-6 md:flex">{linkElements}</nav>
+        <div className="flex items-center gap-3">
+          {session ? (
+            <>
+              <span className="hidden text-sm text-foreground/70 sm:inline">{session.user?.name}</span>
+              <button
+                type="button"
+                onClick={() => signOut()}
+                className="rounded-full border border-accent/40 px-4 py-1.5 text-sm font-semibold text-foreground transition hover:border-accent hover:bg-accent/20"
+              >
+                Sign out
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={() => signIn()}
+                className="rounded-full border border-accent/40 px-4 py-1.5 text-sm font-semibold text-foreground transition hover:border-accent hover:bg-accent/20"
+              >
+                Login
+              </button>
+              <button
+                type="button"
+                onClick={() => signIn("credentials")}
+                className="rounded-full bg-accent px-4 py-1.5 text-sm font-semibold text-white shadow-soft transition hover:translate-y-0.5"
+              >
+                Sign up
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/portal-web/components/providers/session-provider.tsx
+++ b/apps/portal-web/components/providers/session-provider.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { SessionProvider as NextSessionProvider } from "next-auth/react";
+import { ReactNode } from "react";
+
+export function SessionProvider({ children }: { children: ReactNode }) {
+  return <NextSessionProvider>{children}</NextSessionProvider>;
+}

--- a/apps/portal-web/components/ui/exposure-table.tsx
+++ b/apps/portal-web/components/ui/exposure-table.tsx
@@ -1,0 +1,68 @@
+import { ReactNode } from "react";
+
+export type Exposure = {
+  currencyPair: string;
+  netExposure: string;
+  hedged: string;
+  status: "covered" | "warning" | "critical";
+  updatedAt: string;
+};
+
+const statusStyles: Record<Exposure["status"], string> = {
+  covered: "bg-emerald-500/10 text-emerald-300",
+  warning: "bg-amber-500/10 text-amber-200",
+  critical: "bg-rose-500/10 text-rose-200"
+};
+
+const statusCopy: Record<Exposure["status"], ReactNode> = {
+  covered: "On Track",
+  warning: "Rebalance Soon",
+  critical: "Immediate Action"
+};
+
+export function ExposureTable({ rows }: { rows: Exposure[] }) {
+  return (
+    <div className="overflow-hidden rounded-3xl border border-white/10 bg-white/5 backdrop-blur">
+      <table className="min-w-full divide-y divide-white/5 text-left text-sm">
+        <thead className="bg-white/5 text-xs uppercase tracking-wider text-foreground/60">
+          <tr>
+            <th scope="col" className="px-6 py-4">
+              Pair
+            </th>
+            <th scope="col" className="px-6 py-4">
+              Net Exposure
+            </th>
+            <th scope="col" className="px-6 py-4">
+              Hedged %
+            </th>
+            <th scope="col" className="px-6 py-4">
+              Status
+            </th>
+            <th scope="col" className="px-6 py-4">
+              Updated
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-white/5 text-foreground/80">
+          {rows.map((exposure) => (
+            <tr key={exposure.currencyPair} className="hover:bg-white/5">
+              <td className="px-6 py-4 font-semibold text-foreground">
+                {exposure.currencyPair}
+              </td>
+              <td className="px-6 py-4">{exposure.netExposure}</td>
+              <td className="px-6 py-4">{exposure.hedged}</td>
+              <td className="px-6 py-4">
+                <span
+                  className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${statusStyles[exposure.status]}`}
+                >
+                  {statusCopy[exposure.status]}
+                </span>
+              </td>
+              <td className="px-6 py-4 text-foreground/60">{exposure.updatedAt}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/portal-web/components/ui/hedge-card.tsx
+++ b/apps/portal-web/components/ui/hedge-card.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from "react";
+
+type HedgeCardProps = {
+  title: string;
+  subtitle: string;
+  metrics: { label: string; value: string; helper?: ReactNode }[];
+  action?: ReactNode;
+};
+
+export function HedgeCard({ title, subtitle, metrics, action }: HedgeCardProps) {
+  return (
+    <div className="flex flex-col justify-between gap-6 rounded-3xl border border-white/10 bg-white/5 p-6">
+      <div className="space-y-3">
+        <div>
+          <h3 className="text-lg font-semibold text-foreground">{title}</h3>
+          <p className="text-sm text-foreground/60">{subtitle}</p>
+        </div>
+        <dl className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {metrics.map((metric) => (
+            <div key={metric.label} className="rounded-2xl bg-black/20 p-4">
+              <dt className="text-xs uppercase tracking-widest text-foreground/50">{metric.label}</dt>
+              <dd className="mt-2 text-xl font-semibold text-foreground">{metric.value}</dd>
+              {metric.helper ? <div className="mt-1 text-xs text-foreground/60">{metric.helper}</div> : null}
+            </div>
+          ))}
+        </dl>
+      </div>
+      {action ? <div>{action}</div> : null}
+    </div>
+  );
+}

--- a/apps/portal-web/components/ui/quote-slider-card.tsx
+++ b/apps/portal-web/components/ui/quote-slider-card.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+
+type QuoteSliderCardProps = {
+  dealer: string;
+  currencyPair: string;
+  midRate: number;
+  spreadBps: number;
+};
+
+export function QuoteSliderCard({ dealer, currencyPair, midRate, spreadBps }: QuoteSliderCardProps) {
+  const [hedgeRatio, setHedgeRatio] = useState(50);
+  const impliedRate = (midRate * (1 + (spreadBps / 10000) * (hedgeRatio / 100))).toFixed(4);
+
+  return (
+    <div className="flex w-full flex-col gap-4 rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 via-white/5 to-transparent p-6 shadow-soft">
+      <div className="flex items-baseline justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-widest text-foreground/50">{dealer}</p>
+          <h3 className="text-xl font-semibold text-foreground">{currencyPair}</h3>
+        </div>
+        <span className="rounded-full bg-accent/20 px-3 py-1 text-xs font-semibold text-accent">
+          {spreadBps} bps spread
+        </span>
+      </div>
+      <div className="grid gap-2 text-sm">
+        <div className="flex items-center justify-between text-foreground/70">
+          <span>Hedge Ratio</span>
+          <span className="font-semibold text-foreground">{hedgeRatio}%</span>
+        </div>
+        <input
+          type="range"
+          min={0}
+          max={100}
+          value={hedgeRatio}
+          onChange={(event) => setHedgeRatio(Number(event.target.value))}
+          className="accent-accent"
+        />
+        <div className="flex items-center justify-between text-foreground/70">
+          <span>Estimated execution</span>
+          <span className="font-semibold text-foreground">{impliedRate}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/portal-web/lib/auth-options.ts
+++ b/apps/portal-web/lib/auth-options.ts
@@ -1,0 +1,30 @@
+import type { NextAuthOptions } from "next-auth";
+import CredentialsProvider from "next-auth/providers/credentials";
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    CredentialsProvider({
+      name: "Credentials",
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" }
+      },
+      authorize: async (credentials) => {
+        if (!credentials?.email) {
+          return null;
+        }
+        return {
+          id: "1",
+          name: credentials.email.split("@")[0] ?? "Analyst",
+          email: credentials.email
+        };
+      }
+    })
+  ],
+  session: {
+    strategy: "jwt"
+  },
+  pages: {
+    signIn: "/"
+  }
+};

--- a/apps/portal-web/next-env.d.ts
+++ b/apps/portal-web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/portal-web/next.config.js
+++ b/apps/portal-web/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/apps/portal-web/package.json
+++ b/apps/portal-web/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "portal-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "next-auth": "4.23.1",
+    "next-themes": "0.2.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.4.2",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "autoprefixer": "10.4.14",
+    "eslint": "8.51.0",
+    "eslint-config-next": "13.5.6",
+    "postcss": "8.4.23",
+    "tailwindcss": "3.3.3",
+    "typescript": "5.2.2"
+  }
+}

--- a/apps/portal-web/postcss.config.js
+++ b/apps/portal-web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/portal-web/tailwind.config.ts
+++ b/apps/portal-web/tailwind.config.ts
@@ -1,0 +1,34 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: "class",
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+    "./src/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: "#05070d",
+        foreground: "#f4f7ff",
+        accent: {
+          DEFAULT: "#7c5cff",
+          muted: "#362c6b"
+        }
+      },
+      fontFamily: {
+        sans: ["Inter", "ui-sans-serif", "system-ui", "-apple-system", "BlinkMacSystemFont", "Segoe UI", "sans-serif"]
+      },
+      boxShadow: {
+        soft: "0 20px 45px -25px rgba(124, 92, 255, 0.8)"
+      },
+      backgroundImage: {
+        "grid-light": "radial-gradient(circle at 1px 1px, rgba(124,92,255,0.35) 1px, transparent 0)"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/apps/portal-web/tsconfig.json
+++ b/apps/portal-web/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["./components/*"],
+      "@/lib/*": ["./lib/*"],
+      "@/styles/*": ["./app/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fx-option",
+  "private": true,
+  "workspaces": ["apps/*"]
+}


### PR DESCRIPTION
## Summary
- scaffold a dark-themed Next.js portal in apps/portal-web with marketing landing page and primary sections
- add reusable UI kit components for exposures, quote simulation, and hedge playbooks
- configure NextAuth credentials flow, Tailwind theme, and supporting configs for the portal shell

## Testing
- ⚠️ `npm install` *(fails: registry returned 403 Forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7836b0c0832c93f47b664f6cf8ef