### PR TITLE
Add tamper-evident audit logging service and coverage tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # fx-option
+
+Tamper-evident audit logging service for FX option platform.
+
+## Development
+
+Install dependencies using pip:
+
+```bash
+pip install -e .[test]
+```
+
+Run the test suite with coverage enforcement:
+
+```bash
+pytest
+```
+
+Use the `audit_verify` CLI to validate a SQLite audit log file:
+
+```bash
+audit_verify path/to/audit.db
+```

--- a/audit_client/__init__.py
+++ b/audit_client/__init__.py
@@ -1,0 +1,33 @@
+"""Client helper for writing audit log events."""
+from __future__ import annotations
+
+from datetime import datetime
+import sqlite3
+
+from services.audit.db import AuditLogRepository
+from services.audit.chain import AuditRecord
+
+
+class AuditClient:
+    """High level client for appending entries to the audit log."""
+
+    def __init__(self, database_path: str):
+        self._database_path = database_path
+
+    @property
+    def database_path(self) -> str:
+        return self._database_path
+
+    def log(self, actor: str, action: str, payload: object, ts: datetime | None = None) -> AuditRecord:
+        with sqlite3.connect(self._database_path) as conn:
+            repository = AuditLogRepository(conn)
+            return repository.append(actor, action, payload, ts=ts)
+
+    def iter_records(self) -> list[AuditRecord]:
+        with sqlite3.connect(self._database_path) as conn:
+            repository = AuditLogRepository(conn)
+            chain = repository.all_records()
+            return list(chain)
+
+
+__all__ = ["AuditClient", "AuditRecord"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "fx-option"
+version = "0.1.0"
+description = "FX option audit logging service"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{name = "FX Option Team"}]
+dependencies = []
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-cov"
+]
+
+[project.scripts]
+audit_verify = "services.audit.cli:main"
+

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service package namespace."""

--- a/services/audit/__init__.py
+++ b/services/audit/__init__.py
@@ -1,0 +1,11 @@
+"""Audit service package providing tamper-evident logging."""
+
+from .chain import AuditChain, AuditRecord
+from .db import AuditLogRepository, ensure_schema
+
+__all__ = [
+    "AuditChain",
+    "AuditRecord",
+    "AuditLogRepository",
+    "ensure_schema",
+]

--- a/services/audit/chain.py
+++ b/services/audit/chain.py
@@ -1,0 +1,126 @@
+"""Hash-chain based tamper evident audit log primitives."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import hashlib
+import json
+from typing import Iterable, Iterator, List, Sequence
+
+def _canonical_timestamp(value: str | datetime) -> str:
+    """Return a canonical timestamp representation."""
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            raise ValueError("datetime value must be timezone aware")
+        return value.astimezone().isoformat(timespec="microseconds")
+    return value
+
+
+@dataclass(frozen=True)
+class AuditRecord:
+    """Immutable representation of a single audit log entry."""
+
+    id: int
+    ts: str
+    actor: str
+    action: str
+    payload_json: str
+    prev_hash: str
+    this_hash: str
+
+    def canonical_representation(self) -> str:
+        """Serialize the record fields that are protected by the hash."""
+        payload = json.loads(self.payload_json) if self.payload_json else None
+        canonical_payload = json.dumps(payload, sort_keys=True, separators=(",", ":")) if payload is not None else "null"
+        structure = {
+            "actor": self.actor,
+            "action": self.action,
+            "payload": canonical_payload,
+            "prev_hash": self.prev_hash,
+            "ts": self.ts,
+        }
+        return json.dumps(structure, sort_keys=True, separators=(",", ":"))
+
+
+class ChainIntegrityError(RuntimeError):
+    """Raised when the audit log chain verification fails."""
+
+
+class AuditChain:
+    """Utility for computing and verifying audit log hash chains."""
+
+    GENESIS_HASH = "0" * 64
+
+    def __init__(self, records: Sequence[AuditRecord]):
+        self._records: List[AuditRecord] = list(records)
+
+    @staticmethod
+    def compute_hash(prev_hash: str, ts: str | datetime, actor: str, action: str, payload_json: str) -> str:
+        """Compute the hash for the given audit entry."""
+        canonical_payload = AuditChain._canonical_payload(payload_json)
+        canonical_ts = _canonical_timestamp(ts)
+        structure = {
+            "actor": actor,
+            "action": action,
+            "payload": canonical_payload,
+            "prev_hash": prev_hash,
+            "ts": canonical_ts,
+        }
+        digest = hashlib.sha256(json.dumps(structure, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+        return digest.hexdigest()
+
+    @staticmethod
+    def _canonical_payload(payload_json: str) -> str:
+        if not payload_json:
+            return "null"
+        try:
+            parsed = json.loads(payload_json)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive, validated before insert
+            raise ValueError("payload_json must be valid JSON") from exc
+        return json.dumps(parsed, sort_keys=True, separators=(",", ":"))
+
+    def append_hashes(self) -> Iterator[str]:
+        """Yield the expected hash values for the chain."""
+        prev_hash = self.GENESIS_HASH
+        for record in self._records:
+            expected_hash = self.compute_hash(prev_hash, record.ts, record.actor, record.action, record.payload_json)
+            yield expected_hash
+            prev_hash = expected_hash
+
+    def verify(self) -> None:
+        """Verify the audit chain integrity."""
+        prev_hash = self.GENESIS_HASH
+        for record in self._records:
+            expected_hash = self.compute_hash(prev_hash, record.ts, record.actor, record.action, record.payload_json)
+            if record.prev_hash != prev_hash:
+                raise ChainIntegrityError(
+                    f"record {record.id} expected prev_hash {prev_hash} but found {record.prev_hash}"
+                )
+            if record.this_hash != expected_hash:
+                raise ChainIntegrityError(
+                    f"record {record.id} expected this_hash {expected_hash} but found {record.this_hash}"
+                )
+            prev_hash = record.this_hash
+
+    @classmethod
+    def from_rows(cls, rows: Iterable[tuple]) -> "AuditChain":
+        """Build a chain from raw database rows."""
+        records = [
+            AuditRecord(
+                id=row[0],
+                ts=row[1],
+                actor=row[2],
+                action=row[3],
+                payload_json=row[4],
+                prev_hash=row[5],
+                this_hash=row[6],
+            )
+            for row in rows
+        ]
+        return cls(records)
+
+    def __iter__(self) -> Iterator[AuditRecord]:
+        return iter(self._records)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial accessor
+        return len(self._records)

--- a/services/audit/cli.py
+++ b/services/audit/cli.py
@@ -1,0 +1,33 @@
+"""CLI tool to verify audit log integrity."""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+
+from .chain import ChainIntegrityError
+from .db import AuditLogRepository
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the audit_verify command."""
+    parser = argparse.ArgumentParser(description="Verify the tamper-evident audit log chain")
+    parser.add_argument("database", help="Path to the SQLite database file containing audit_log")
+    args = parser.parse_args(argv)
+
+    conn = sqlite3.connect(args.database)
+    try:
+        repository = AuditLogRepository(conn)
+        repository.verify()
+        count = conn.execute("SELECT COUNT(*) FROM audit_log").fetchone()[0]
+        print(f"audit log ok: {count} entries verified")
+        return 0
+    except ChainIntegrityError as exc:
+        print(f"audit log verification failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI passthrough
+    sys.exit(main())

--- a/services/audit/db.py
+++ b/services/audit/db.py
@@ -1,0 +1,91 @@
+"""SQLite backed audit log repository."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import sqlite3
+
+from .chain import AuditChain, AuditRecord
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts TEXT NOT NULL,
+    actor TEXT NOT NULL,
+    action TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    prev_hash TEXT NOT NULL,
+    this_hash TEXT NOT NULL
+);
+"""
+
+
+def ensure_schema(conn: sqlite3.Connection) -> None:
+    """Ensure the audit_log table exists."""
+    conn.execute(SCHEMA)
+    conn.commit()
+
+
+class AuditLogRepository:
+    """Repository providing append-only access to the audit log."""
+
+    def __init__(self, conn: sqlite3.Connection):
+        self._conn = conn
+        ensure_schema(self._conn)
+
+    def append(self, actor: str, action: str, payload: object, ts: datetime | None = None) -> AuditRecord:
+        """Append a new audit entry."""
+        timestamp = self._canonical_timestamp(ts)
+        payload_json = self._canonical_payload(payload)
+        prev_hash = self._previous_hash()
+        this_hash = AuditChain.compute_hash(prev_hash, timestamp, actor, action, payload_json)
+        cursor = self._conn.execute(
+            """
+            INSERT INTO audit_log (ts, actor, action, payload_json, prev_hash, this_hash)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (timestamp, actor, action, payload_json, prev_hash, this_hash),
+        )
+        self._conn.commit()
+        rowid = cursor.lastrowid
+        return AuditRecord(rowid, timestamp, actor, action, payload_json, prev_hash, this_hash)
+
+    def all_records(self) -> AuditChain:
+        """Return all audit records ordered by id."""
+        cursor = self._conn.execute(
+            "SELECT id, ts, actor, action, payload_json, prev_hash, this_hash FROM audit_log ORDER BY id"
+        )
+        rows = cursor.fetchall()
+        return AuditChain.from_rows(rows)
+
+    def verify(self) -> None:
+        """Verify the integrity of the stored chain."""
+        chain = self.all_records()
+        chain.verify()
+
+    def _previous_hash(self) -> str:
+        row = self._conn.execute("SELECT this_hash FROM audit_log ORDER BY id DESC LIMIT 1").fetchone()
+        if row is None:
+            return AuditChain.GENESIS_HASH
+        return row[0]
+
+    @staticmethod
+    def _canonical_timestamp(ts: datetime | None) -> str:
+        if ts is None:
+            ts = datetime.now(timezone.utc)
+        if ts.tzinfo is None:
+            raise ValueError("timestamp must be timezone aware")
+        return ts.astimezone(timezone.utc).isoformat(timespec="microseconds")
+
+    @staticmethod
+    def _canonical_payload(payload: object) -> str:
+        if payload is None:
+            return "null"
+        if isinstance(payload, str):
+            parsed = json.loads(payload)
+        else:
+            parsed = payload
+        return json.dumps(parsed, sort_keys=True, separators=(",", ":"))
+
+
+__all__ = ["AuditLogRepository", "ensure_schema", "SCHEMA"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_audit_chain.py
+++ b/tests/test_audit_chain.py
@@ -1,0 +1,231 @@
+import ast
+import json
+import inspect
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from trace import Trace
+
+import pytest
+
+from audit_client import AuditClient
+from services.audit.chain import AuditChain, ChainIntegrityError
+from services.audit.cli import main as audit_verify_main
+from services.audit.db import AuditLogRepository
+import services.audit.chain as chain_module
+
+
+def create_repository(db_path: str) -> AuditLogRepository:
+    conn = sqlite3.connect(db_path)
+    return AuditLogRepository(conn)
+
+
+def test_repository_append_and_verify(tmp_path):
+    db_path = tmp_path / "audit.db"
+    repo = create_repository(db_path)
+    first = repo.append("user", "create", {"amount": 10})
+    assert first.prev_hash == AuditChain.GENESIS_HASH
+
+    repo.append("user", "update", json.dumps({"status": "ok"}))
+    repo.append("system", "heartbeat", None)
+
+    chain = repo.all_records()
+    chain.verify()
+
+    computed_hashes = list(chain.append_hashes())
+    stored_hashes = [record.this_hash for record in chain]
+    assert computed_hashes == stored_hashes
+
+    canonical = [record.canonical_representation() for record in chain]
+    assert all(isinstance(value, str) for value in canonical)
+
+    repo._conn.close()
+
+
+def test_repository_rejects_naive_timestamp(tmp_path):
+    db_path = tmp_path / "audit.db"
+    repo = create_repository(db_path)
+    naive = datetime(2024, 1, 1, 12, 0, 0)
+    with pytest.raises(ValueError):
+        repo.append("user", "create", {}, ts=naive)
+    repo._conn.close()
+
+
+def test_chain_detects_tampered_prev_hash(tmp_path):
+    db_path = tmp_path / "audit.db"
+    repo = create_repository(db_path)
+    repo.append("user", "create", {"amount": 10})
+    repo.append("user", "update", {"amount": 20})
+    repo.append("user", "close", {"amount": 30})
+    repo._conn.execute("UPDATE audit_log SET prev_hash = 'corrupt' WHERE id = 2")
+    repo._conn.commit()
+
+    with pytest.raises(ChainIntegrityError):
+        repo.verify()
+    repo._conn.close()
+
+
+def test_chain_detects_tampered_hash(tmp_path):
+    db_path = tmp_path / "audit.db"
+    repo = create_repository(db_path)
+    repo.append("user", "create", {"amount": 10})
+    repo.append("user", "update", {"amount": 20})
+    repo.append("user", "close", {"amount": 30})
+    repo._conn.execute("UPDATE audit_log SET payload_json = '{\"amount\":999}' WHERE id = 3")
+    repo._conn.commit()
+
+    with pytest.raises(ChainIntegrityError):
+        repo.verify()
+    repo._conn.close()
+
+
+def test_audit_client_log_and_iter(tmp_path):
+    db_path = tmp_path / "audit.db"
+    client = AuditClient(str(db_path))
+    timestamp = datetime.now(timezone.utc)
+    client.log("svc", "emit", {"value": 1}, ts=timestamp)
+    client.log("svc", "emit", {"value": 2}, ts=timestamp)
+
+    records = client.iter_records()
+    assert len(records) == 2
+    assert records[0].actor == "svc"
+
+
+def test_cli_success(tmp_path, capsys):
+    db_path = tmp_path / "audit.db"
+    repo = create_repository(db_path)
+    repo.append("user", "create", {"amount": 10})
+    repo.append("user", "update", {"amount": 20})
+    repo._conn.close()
+
+    exit_code = audit_verify_main([str(db_path)])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "audit log ok" in captured.out
+
+
+def test_cli_failure(tmp_path, capsys):
+    db_path = tmp_path / "audit.db"
+    repo = create_repository(db_path)
+    repo.append("user", "create", {"amount": 10})
+    repo.append("user", "update", {"amount": 20})
+    repo._conn.execute("UPDATE audit_log SET action = 'tampered' WHERE id = 2")
+    repo._conn.commit()
+    repo._conn.close()
+
+    exit_code = audit_verify_main([str(db_path)])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "verification failed" in captured.err
+
+
+def test_compute_hash_handles_empty_payload():
+    ts = datetime.now(timezone.utc).isoformat(timespec="microseconds")
+    hashed_null = AuditChain.compute_hash(AuditChain.GENESIS_HASH, ts, "actor", "action", "null")
+    hashed_empty = AuditChain.compute_hash(AuditChain.GENESIS_HASH, ts, "actor", "action", "")
+    assert hashed_null == hashed_empty
+
+
+def _function_lines(module) -> set[int]:
+    source = Path(module.__file__).read_text()
+    tree = ast.parse(source)
+    lines: set[int] = set()
+
+    def is_docstring(node: ast.stmt) -> bool:
+        return isinstance(node, ast.Expr) and isinstance(getattr(node, "value", None), ast.Constant) and isinstance(
+            node.value.value, str
+        )
+
+    source_lines = source.splitlines()
+
+    def collect_body(body: list[ast.stmt]) -> None:
+        for stmt in body:
+            if is_docstring(stmt):
+                continue
+            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                continue
+            lineno = getattr(stmt, "lineno", None)
+            if lineno is not None:
+                lines.add(lineno)
+            for child in ast.walk(stmt):
+                if child is stmt or not isinstance(child, ast.stmt):
+                    continue
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                    continue
+                if is_docstring(child):
+                    continue
+                lineno = getattr(child, "lineno", None)
+                if lineno is not None:
+                    lines.add(lineno)
+
+    class Visitor(ast.NodeVisitor):
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            if "# pragma: no cover" in source_lines[node.lineno - 1]:
+                return
+            collect_body(node.body)
+            self.generic_visit(node)
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # pragma: no cover - no async in module
+            collect_body(node.body)
+            self.generic_visit(node)
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            for stmt in node.body:
+                if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    self.visit(stmt)
+
+    Visitor().visit(tree)
+    return lines
+
+
+def test_chain_module_has_full_coverage(tmp_path):
+    db_path = tmp_path / "coverage.db"
+    db_path_secondary = tmp_path / "coverage_tamper.db"
+
+    def exercise_primary():
+        repo = create_repository(db_path)
+        aware = datetime.now(timezone.utc)
+        repo.append("user", "create", {"amount": 1}, ts=aware)
+        repo.append("user", "update", json.dumps({"status": "ok"}))
+        repo.append("system", "heartbeat", None)
+        chain = repo.all_records()
+        list(chain.append_hashes())
+        for record in chain:
+            record.canonical_representation()
+        repo.verify()
+        chain_module._canonical_timestamp(aware)
+        AuditChain.compute_hash(AuditChain.GENESIS_HASH, aware.isoformat(timespec="microseconds"), "user", "noop", "")
+        try:
+            chain_module._canonical_timestamp(datetime(2024, 1, 1, 0, 0, 0))
+        except ValueError:
+            pass
+        with pytest.raises(ValueError):
+            AuditChain._canonical_payload("not-json")
+        repo._conn.execute("UPDATE audit_log SET prev_hash = 'bad' WHERE id = 2")
+        repo._conn.commit()
+        with pytest.raises(ChainIntegrityError):
+            repo.verify()
+        repo._conn.close()
+
+    def exercise_secondary():
+        repo = create_repository(db_path_secondary)
+        repo.append("user", "create", {"amount": 1})
+        repo.append("user", "update", {"amount": 2})
+        repo.append("user", "close", {"amount": 3})
+        repo._conn.execute("UPDATE audit_log SET payload_json = '{\"amount\":999}' WHERE id = 3")
+        repo._conn.commit()
+        tampered_chain = repo.all_records()
+        with pytest.raises(ChainIntegrityError):
+            tampered_chain.verify()
+        repo._conn.close()
+
+    tracer = Trace(count=True, trace=False)
+    tracer.runfunc(exercise_primary)
+    tracer.runfunc(exercise_secondary)
+
+    results = tracer.results()
+    module_path = Path(chain_module.__file__).resolve()
+    executed = {lineno for (filename, lineno), _ in results.counts.items() if Path(filename).resolve() == module_path}
+    required = _function_lines(chain_module)
+    missing = sorted(required - executed)
+    assert not missing, f"Missing coverage lines: {missing}"


### PR DESCRIPTION
## Summary
- implement hash-chained audit log primitives with a SQLite repository and verification CLI
- provide an audit_client helper so services can append tamper-evident events
- document project usage and enforce chain coverage with dedicated unit tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cc786a97a0832c9e2035d1878575f1