### PR TITLE
Add QuickBooks Online connector service

### DIFF
--- a/docs/connectors/QBO.md
+++ b/docs/connectors/QBO.md
@@ -1,0 +1,85 @@
+# QuickBooks Online Connector
+
+This service listens for QuickBooks Online (QBO) invoice webhooks and publishes
+`ExposureCreated` events whenever a foreign-currency invoice with a due date is
+observed.
+
+## Overview
+
+* **Location:** `services/connectors/qbo`
+* **Runtime:** Python 3.11, FastAPI
+* **Primary entrypoint:** `services/connectors/qbo/app.py`
+
+## Environment variables
+
+| Variable | Description |
+| --- | --- |
+| `QBO_CLIENT_ID` | OAuth2 client id from the Intuit developer portal. |
+| `QBO_CLIENT_SECRET` | OAuth2 client secret. |
+| `QBO_REDIRECT_URI` | Redirect URI registered with Intuit. |
+| `QBO_REALM_ID` | Company realm identifier. |
+| `QBO_WEBHOOK_VERIFIER_TOKEN` | Token used to validate webhook signatures. |
+| `QBO_ENVIRONMENT` | `sandbox` (default) or `production`. |
+| `QBO_EXPOSURE_TOPIC` | Topic used when emitting `ExposureCreated` events. |
+| `QBO_HTTP_TIMEOUT` | Optional HTTP timeout in seconds (default `2.5`). |
+
+## OAuth2
+
+The connector exposes a FastAPI application that can be paired with the
+standard Intuit OAuth2 authorization code flow. The `QBOOAuthClient` exchanges
+authorization codes and refreshes tokens using the Intuit token endpoint.
+Tokens are persisted in-memory via `TokenStore`; replace this with a durable
+backend (e.g. Redis) for production use.
+
+## Webhook processing
+
+The `/qbo/webhook` endpoint validates incoming Intuit webhook signatures using
+the HMAC-SHA256 algorithm. Only `Invoice.Create` and `Invoice.Update` events are
+processed. Each event is handled in a background task to ensure the webhook
+response is returned in well under three seconds.
+
+For each invoice:
+
+1. Fetch the full invoice payload via the QBO API.
+2. Retrieve the company's home currency from `CompanyInfo` (cached in-memory).
+3. Skip invoices without a due date or without a currency code.
+4. Ignore invoices denominated in the home currency.
+5. Emit an `ExposureCreated` event for every foreign-currency invoice with a due
+   date.
+
+## Exposure payload
+
+The emitted event is logged in JSON form by `ExposureEmitter`. Integrate this
+class with the internal message bus to deliver the payload downstream. The
+structure is:
+
+```json
+{
+  "type": "ExposureCreated",
+  "topic": "exposure.created",
+  "invoice_id": "123",
+  "amount": 102.56,
+  "currency": "EUR",
+  "due_date": "2024-02-20",
+  "counterparty": "ACME GmbH",
+  "metadata": {
+    "doc_number": "INV-123",
+    "status": "Open",
+    "link": "123"
+  }
+}
+```
+
+## Running locally
+
+Create a virtual environment and install dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn services.connectors.qbo.app:app --reload
+```
+
+Configure a public HTTPS endpoint (for example using ngrok) and register it in
+the Intuit developer portal to receive invoice webhooks.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.110.0
+httpx==0.27.0
+uvicorn==0.29.0
+pytest==8.2.0

--- a/services/connectors/qbo/app.py
+++ b/services/connectors/qbo/app.py
@@ -1,0 +1,37 @@
+"""FastAPI application exposing the QBO connector."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+from fastapi import FastAPI
+
+from .config import Settings
+from .qbo_client import QBOClient
+from .oauth import QBOOAuthClient
+from .webhook import router as webhook_router
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="QBO Connector")
+app.include_router(webhook_router, prefix="/qbo")
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    settings = Settings.get()
+    oauth = QBOOAuthClient(settings)
+    client = QBOClient(settings, oauth)
+    try:
+        await client.ensure_webhook_subscription("https://example.com/qbo/webhook")
+    except Exception:  # pylint: disable=broad-except
+        logger.warning("Webhook subscription validation failed", exc_info=True)
+
+
+@app.get("/health")
+async def healthcheck() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+__all__ = ["app"]

--- a/services/connectors/qbo/config.py
+++ b/services/connectors/qbo/config.py
@@ -1,0 +1,57 @@
+"""Configuration helpers for the QuickBooks Online connector."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class QBOConfig:
+    """Runtime configuration for the QBO connector."""
+
+    client_id: str
+    client_secret: str
+    redirect_uri: str
+    realm_id: str
+    environment: str = "sandbox"
+    webhook_verifier_token: str = ""
+    exposure_topic: str = "exposure.created"
+    http_timeout: float = 2.5
+
+    @classmethod
+    def from_env(cls) -> "QBOConfig":
+        """Load configuration from environment variables."""
+
+        def require(name: str) -> str:
+            value = os.getenv(name)
+            if not value:
+                raise RuntimeError(f"Missing required environment variable: {name}")
+            return value
+
+        return cls(
+            client_id=require("QBO_CLIENT_ID"),
+            client_secret=require("QBO_CLIENT_SECRET"),
+            redirect_uri=require("QBO_REDIRECT_URI"),
+            realm_id=require("QBO_REALM_ID"),
+            environment=os.getenv("QBO_ENVIRONMENT", "sandbox"),
+            webhook_verifier_token=require("QBO_WEBHOOK_VERIFIER_TOKEN"),
+            exposure_topic=os.getenv("QBO_EXPOSURE_TOPIC", "exposure.created"),
+            http_timeout=float(os.getenv("QBO_HTTP_TIMEOUT", "2.5")),
+        )
+
+
+class Settings:
+    """Global settings container used to cache runtime configuration."""
+
+    _config: Optional[QBOConfig] = None
+
+    @classmethod
+    def get(cls) -> QBOConfig:
+        if cls._config is None:
+            cls._config = QBOConfig.from_env()
+        return cls._config
+
+
+__all__ = ["QBOConfig", "Settings"]

--- a/services/connectors/qbo/exposures.py
+++ b/services/connectors/qbo/exposures.py
@@ -1,0 +1,47 @@
+"""Exposure event emitter."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ExposureEvent:
+    invoice_id: str
+    amount: float
+    currency: str
+    due_date: str
+    counterparty: str
+    metadata: Dict[str, Any]
+
+
+class ExposureEmitter:
+    """Publish exposure events to the internal event bus.
+
+    The default implementation simply logs the payload. Replace with the
+    appropriate message bus producer in production.
+    """
+
+    def __init__(self, topic: str) -> None:
+        self.topic = topic
+
+    async def emit(self, event: ExposureEvent) -> None:
+        payload = {
+            "type": "ExposureCreated",
+            "topic": self.topic,
+            "invoice_id": event.invoice_id,
+            "amount": event.amount,
+            "currency": event.currency,
+            "due_date": event.due_date,
+            "counterparty": event.counterparty,
+            "metadata": event.metadata,
+        }
+        logger.info("Emitting exposure event: %s", json.dumps(payload, sort_keys=True))
+
+
+__all__ = ["ExposureEmitter", "ExposureEvent"]

--- a/services/connectors/qbo/oauth.py
+++ b/services/connectors/qbo/oauth.py
@@ -1,0 +1,84 @@
+"""OAuth2 helpers for QuickBooks Online."""
+
+from __future__ import annotations
+
+import time
+from typing import Dict, Optional
+
+import httpx
+
+from .config import QBOConfig
+
+
+class TokenStore:
+    """Simple in-memory token store.
+
+    In production this should be backed by a persistent datastore.
+    """
+
+    def __init__(self) -> None:
+        self._data: Dict[str, Dict[str, str]] = {}
+
+    def save(self, realm_id: str, tokens: Dict[str, str]) -> None:
+        self._data[realm_id] = tokens
+
+    def get(self, realm_id: str) -> Optional[Dict[str, str]]:
+        return self._data.get(realm_id)
+
+
+class OAuthError(RuntimeError):
+    """Raised when an OAuth operation fails."""
+
+
+class QBOOAuthClient:
+    token_url = "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer"
+
+    def __init__(self, config: QBOConfig, store: Optional[TokenStore] = None) -> None:
+        self.config = config
+        self.store = store or TokenStore()
+
+    async def exchange_code(self, code: str) -> Dict[str, str]:
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": self.config.redirect_uri,
+        }
+        return await self._request_token(data)
+
+    async def refresh(self, refresh_token: str) -> Dict[str, str]:
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+        }
+        return await self._request_token(data)
+
+    async def get_access_token(self) -> str:
+        tokens = self.store.get(self.config.realm_id)
+        if not tokens:
+            raise OAuthError("No tokens available for realm")
+
+        expiry = tokens.get("expires_at")
+        if not expiry or float(expiry) <= time.time() + 60:
+            tokens = await self.refresh(tokens["refresh_token"])
+
+        return tokens["access_token"]
+
+    async def _request_token(self, data: Dict[str, str]) -> Dict[str, str]:
+        auth = (self.config.client_id, self.config.client_secret)
+        async with httpx.AsyncClient(timeout=self.config.http_timeout) as client:
+            response = await client.post(self.token_url, data=data, auth=auth)
+            if response.status_code >= 400:
+                raise OAuthError(f"OAuth token request failed: {response.text}")
+            payload = response.json()
+
+        tokens = {
+            "access_token": payload["access_token"],
+            "refresh_token": payload["refresh_token"],
+            "token_type": payload.get("token_type", "bearer"),
+            "expires_at": str(time.time() + payload.get("expires_in", 3600)),
+        }
+        self.store.save(self.config.realm_id, tokens)
+        return tokens
+
+
+__all__ = ["OAuthError", "QBOOAuthClient", "TokenStore"]

--- a/services/connectors/qbo/qbo_client.py
+++ b/services/connectors/qbo/qbo_client.py
@@ -1,0 +1,73 @@
+"""Async client wrapper for QuickBooks Online APIs."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import httpx
+
+from .config import QBOConfig
+from .oauth import OAuthError, QBOOAuthClient
+
+
+class QBOClient:
+    base_url = "https://sandbox-quickbooks.api.intuit.com"  # default
+
+    def __init__(self, config: QBOConfig, oauth: QBOOAuthClient) -> None:
+        self.config = config
+        self.oauth = oauth
+        if config.environment == "production":
+            self.base_url = "https://quickbooks.api.intuit.com"
+        self._company_currency: Optional[str] = None
+
+    async def _headers(self) -> Dict[str, str]:
+        token = await self.oauth.get_access_token()
+        return {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+    async def get_invoice(self, invoice_id: str) -> Dict[str, Any]:
+        url = f"{self.base_url}/v3/company/{self.config.realm_id}/invoice/{invoice_id}"
+        params = {"minorversion": "65"}
+        async with httpx.AsyncClient(timeout=self.config.http_timeout) as client:
+            response = await client.get(url, headers=await self._headers(), params=params)
+        if response.status_code == 404:
+            raise KeyError(f"Invoice {invoice_id} not found")
+        if response.status_code >= 400:
+            raise RuntimeError(f"Invoice fetch failed: {response.text}")
+        data = response.json()
+        return data["Invoice"] if "Invoice" in data else data
+
+    async def get_company_currency(self) -> str:
+        if self._company_currency:
+            return self._company_currency
+
+        url = f"{self.base_url}/v3/company/{self.config.realm_id}/companyinfo/{self.config.realm_id}"
+        async with httpx.AsyncClient(timeout=self.config.http_timeout) as client:
+            response = await client.get(url, headers=await self._headers())
+        if response.status_code >= 400:
+            raise RuntimeError(f"Company info fetch failed: {response.text}")
+        payload = response.json()
+        info = payload.get("CompanyInfo", {})
+        currency = info.get("HomeCurrency") or info.get("CurrencyRef", {}).get("value")
+        if not currency:
+            raise RuntimeError("Could not determine home currency")
+        self._company_currency = currency
+        return currency
+
+    async def ensure_webhook_subscription(self, endpoint_url: str) -> None:
+        """Ensures the webhook subscription exists.
+
+        Intuit manages subscriptions through the developer portal; this method is a
+        best-effort helper that records intent and validates configuration.
+        """
+
+        if not endpoint_url.startswith("https://"):
+            raise ValueError("Webhook endpoint must be https")
+        # In production you would call the Subscriptions API here. For now we
+        # simply validate configuration to avoid silent misconfiguration.
+
+
+__all__ = ["QBOClient"]

--- a/services/connectors/qbo/webhook.py
+++ b/services/connectors/qbo/webhook.py
@@ -1,0 +1,113 @@
+"""Webhook handling for QuickBooks Online invoice events."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import logging
+from typing import Any, Dict, Iterable
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
+
+from .config import Settings
+from .exposures import ExposureEmitter, ExposureEvent
+from .oauth import QBOOAuthClient
+from .qbo_client import QBOClient
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _verify_signature(raw_body: bytes, signature: str, token: str) -> bool:
+    digest = hmac.new(token.encode(), raw_body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(digest, signature)
+
+
+def _iter_invoice_events(payload: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
+    for event in payload.get("eventNotifications", []):
+        for entity in event.get("dataChangeEvent", {}).get("entities", []):
+            if entity.get("name") == "Invoice" and entity.get("operation") in {"Create", "Update"}:
+                yield entity
+
+
+async def _process_invoice(
+    client: QBOClient,
+    emitter: ExposureEmitter,
+    entity: Dict[str, Any],
+) -> None:
+    invoice_id = entity.get("id")
+    if not invoice_id:
+        logger.warning("Skipping invoice event without id: %s", entity)
+        return
+
+    try:
+        invoice = await client.get_invoice(invoice_id)
+    except KeyError:
+        logger.info("Invoice %s no longer exists", invoice_id)
+        return
+    except Exception:  # pylint: disable=broad-except
+        logger.exception("Failed to fetch invoice %s", invoice_id)
+        return
+
+    due_date = invoice.get("DueDate")
+    currency = invoice.get("CurrencyRef", {}).get("value")
+    company_currency = await client.get_company_currency()
+
+    if not due_date or not currency:
+        logger.debug("Invoice %s missing due date or currency", invoice_id)
+        return
+
+    if currency == company_currency:
+        logger.debug("Invoice %s is in home currency %s", invoice_id, currency)
+        return
+
+    amount = float(invoice.get("TotalAmt", 0))
+    counterparty = invoice.get("CustomerRef", {}).get("name", "Unknown")
+
+    event = ExposureEvent(
+        invoice_id=str(invoice_id),
+        amount=amount,
+        currency=currency,
+        due_date=due_date,
+        counterparty=counterparty,
+        metadata={
+            "doc_number": invoice.get("DocNumber"),
+            "status": invoice.get("Balance") and ("Open" if invoice.get("Balance") else "Paid"),
+            "link": invoice.get("Id"),
+        },
+    )
+    await emitter.emit(event)
+
+
+@router.post("/webhook")
+async def handle_webhook(request: Request, background: BackgroundTasks) -> Dict[str, str]:
+    settings = Settings.get()
+    raw_body = await request.body()
+    signature = request.headers.get("intuit-signature")
+    if not signature or not _verify_signature(raw_body, signature, settings.webhook_verifier_token):
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")
+
+    try:
+        payload = json.loads(raw_body.decode("utf-8"))
+    except json.JSONDecodeError as exc:  # pragma: no cover - FastAPI handles
+        raise HTTPException(status_code=400, detail="Invalid JSON payload") from exc
+
+    entities = list(_iter_invoice_events(payload))
+    if not entities:
+        return {"status": "ignored"}
+
+    oauth = QBOOAuthClient(settings)
+    client = QBOClient(settings, oauth)
+    emitter = ExposureEmitter(settings.exposure_topic)
+
+    async def process_all() -> None:
+        await asyncio.gather(*(_process_invoice(client, emitter, entity) for entity in entities))
+
+    background.add_task(process_all)
+    return {"status": "accepted"}
+
+
+__all__ = ["router"]

--- a/tests/services/connectors/qbo/test_webhook.py
+++ b/tests/services/connectors/qbo/test_webhook.py
@@ -1,0 +1,148 @@
+"""Tests for the QBO webhook handler."""
+
+from __future__ import annotations
+
+import hmac
+import hashlib
+import json
+from typing import Any, Dict, List
+
+import pytest
+from fastapi.testclient import TestClient
+
+from services.connectors.qbo.app import app
+from services.connectors.qbo import webhook
+
+
+@pytest.fixture(autouse=True)
+def setup_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QBO_CLIENT_ID", "id")
+    monkeypatch.setenv("QBO_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("QBO_REDIRECT_URI", "https://example.com/callback")
+    monkeypatch.setenv("QBO_REALM_ID", "12345")
+    monkeypatch.setenv("QBO_WEBHOOK_VERIFIER_TOKEN", "token")
+
+
+def _sign(payload: Dict[str, Any], token: str) -> str:
+    body = json.dumps(payload).encode("utf-8")
+    return hmac.new(token.encode(), body, hashlib.sha256).hexdigest()
+
+
+class DummyEmitter:
+    def __init__(self, *_: Any, **__: Any) -> None:
+        self.events: List[Dict[str, Any]] = []
+
+    async def emit(self, event: Any) -> None:  # pragma: no cover - type ignore
+        self.events.append(event.__dict__)
+
+
+class DummyClient:
+    def __init__(self, *_: Any, **__: Any) -> None:
+        self.invoice = {
+            "Id": "99",
+            "DueDate": "2024-04-01",
+            "CurrencyRef": {"value": "EUR"},
+            "TotalAmt": "120.55",
+            "CustomerRef": {"name": "ACME GmbH"},
+            "DocNumber": "INV-99",
+            "Balance": 120.55,
+        }
+
+    async def get_invoice(self, _: str) -> Dict[str, Any]:
+        return self.invoice
+
+    async def get_company_currency(self) -> str:
+        return "USD"
+
+    async def ensure_webhook_subscription(self, *_: Any, **__: Any) -> None:
+        return None
+
+
+class DummyOAuth:
+    def __init__(self, *_: Any, **__: Any) -> None:
+        pass
+
+    async def get_access_token(self) -> str:
+        return "token"
+
+
+@pytest.mark.asyncio
+async def test_verify_signature() -> None:
+    token = "token"
+    payload = {"foo": "bar"}
+    body = json.dumps(payload).encode("utf-8")
+    signature = webhook._verify_signature(body, _sign(payload, token), token)
+    assert signature is True
+
+
+def test_webhook_emits_exposure(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy_emitter = DummyEmitter()
+    monkeypatch.setattr(webhook, "ExposureEmitter", lambda *_: dummy_emitter)
+    monkeypatch.setattr(webhook, "QBOClient", DummyClient)
+    monkeypatch.setattr(webhook, "QBOOAuthClient", DummyOAuth)
+    monkeypatch.setattr("services.connectors.qbo.app.QBOClient", DummyClient)
+    monkeypatch.setattr("services.connectors.qbo.app.QBOOAuthClient", DummyOAuth)
+
+    payload = {
+        "eventNotifications": [
+            {
+                "dataChangeEvent": {
+                    "entities": [
+                        {"name": "Invoice", "operation": "Create", "id": "99"}
+                    ]
+                }
+            }
+        ]
+    }
+
+    headers = {"intuit-signature": _sign(payload, "token")}
+
+    client = TestClient(app)
+    response = client.post("/qbo/webhook", json=payload, headers=headers)
+    assert response.status_code == 200
+    assert response.json() == {"status": "accepted"}
+    assert dummy_emitter.events
+    event = dummy_emitter.events[0]
+    assert event["currency"] == "EUR"
+    assert event["due_date"] == "2024-04-01"
+
+
+def test_webhook_ignores_home_currency(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy_emitter = DummyEmitter()
+    monkeypatch.setattr(webhook, "ExposureEmitter", lambda *_: dummy_emitter)
+    monkeypatch.setattr(webhook, "QBOClient", DummyClient)
+    monkeypatch.setattr(webhook, "QBOOAuthClient", DummyOAuth)
+    monkeypatch.setattr("services.connectors.qbo.app.QBOClient", DummyClient)
+    monkeypatch.setattr("services.connectors.qbo.app.QBOOAuthClient", DummyOAuth)
+
+    payload = {
+        "eventNotifications": [
+            {
+                "dataChangeEvent": {
+                    "entities": [
+                        {"name": "Invoice", "operation": "Update", "id": "99"}
+                    ]
+                }
+            }
+        ]
+    }
+
+    headers = {"intuit-signature": _sign(payload, "token")}
+
+    dummy_client = DummyClient()
+    dummy_client.invoice["CurrencyRef"]["value"] = "USD"
+    monkeypatch.setattr(webhook, "QBOClient", lambda *_: dummy_client)
+
+    client = TestClient(app)
+    response = client.post("/qbo/webhook", json=payload, headers=headers)
+    assert response.status_code == 200
+    assert response.json() == {"status": "accepted"}
+    assert not dummy_emitter.events
+
+
+def test_webhook_invalid_signature() -> None:
+    payload = {}
+    headers = {"intuit-signature": "invalid"}
+    client = TestClient(app)
+    response = client.post("/qbo/webhook", json=payload, headers=headers)
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary
- add a FastAPI-based QuickBooks Online connector capable of validating webhook signatures
- implement OAuth2 helpers, invoice fetching logic, and exposure emission for foreign-currency invoices
- document configuration and local usage in `docs/connectors/QBO.md`

## Testing
- ⚠️ `pip install -r requirements.txt` *(fails: ProxyError(\"Cannot connect to proxy.\"))*
- ⚠️ `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi' because dependency installation is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68cc78b27b80832c994185625f3a06e2