### PR TITLE
Add pricing orchestrator service

### DIFF
--- a/services/pricing-orchestrator/README.md
+++ b/services/pricing-orchestrator/README.md
@@ -1,0 +1,18 @@
+# Pricing Orchestrator Service
+
+This service coordinates market data retrieval, pricing, persistence, and event emission for binding FX option quotes. It listens for `ExposureCreated` events, enriches them with spot, implied volatility, and rate information, and then delegates price calculation to the configured pricing engine. Quotes are persisted with a strict two-minute validity window and a configurable safety buffer before notifying downstream systems via the message bus.
+
+## Key behaviours
+
+* Enforces the business default of a **5% cap when implied volatility is below 2%**.
+* Quotes have a validity of 120 seconds; consumers are expected to respect the configured safety buffer to avoid stale execution.
+* Captures and raises when the 99th percentile SLA of 200ms is breached to surface operational issues early.
+* Produces a graceful manual-intervention message when the required market data is unavailable.
+
+## Tests
+
+Run the test suite with:
+
+```bash
+python -m pytest services/pricing-orchestrator/tests
+```

--- a/services/pricing-orchestrator/pyproject.toml
+++ b/services/pricing-orchestrator/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pricing-orchestrator"
+version = "0.1.0"
+description = "Orchestrates FX option quote generation"
+authors = [{name = "FX Options Team"}]
+readme = "README.md"
+requires-python = ">=3.10"
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+pythonpath = ["src"]

--- a/services/pricing-orchestrator/src/pricing_orchestrator/__init__.py
+++ b/services/pricing-orchestrator/src/pricing_orchestrator/__init__.py
@@ -1,0 +1,35 @@
+"""Pricing orchestrator service."""
+
+from .domain import (
+    ExposureCreated,
+    MarketDataSnapshot,
+    PricingRequest,
+    Quote,
+    QuoteComputation,
+    QuoteOrchestrationResult,
+    QuoteReady,
+)
+from .orchestrator import (
+    DEFAULT_CAP,
+    DEFAULT_SAFETY_BUFFER_SECONDS,
+    DEFAULT_VOLATILITY_THRESHOLD,
+    QUOTE_VALIDITY_SECONDS,
+    QuoteOrchestrator,
+    SLAExceededError,
+)
+
+__all__ = [
+    "ExposureCreated",
+    "MarketDataSnapshot",
+    "PricingRequest",
+    "Quote",
+    "QuoteComputation",
+    "QuoteOrchestrationResult",
+    "QuoteReady",
+    "DEFAULT_CAP",
+    "DEFAULT_SAFETY_BUFFER_SECONDS",
+    "DEFAULT_VOLATILITY_THRESHOLD",
+    "QUOTE_VALIDITY_SECONDS",
+    "QuoteOrchestrator",
+    "SLAExceededError",
+]

--- a/services/pricing-orchestrator/src/pricing_orchestrator/domain.py
+++ b/services/pricing-orchestrator/src/pricing_orchestrator/domain.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from decimal import Decimal
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ExposureCreated:
+    """Event emitted when a new exposure is ready for pricing."""
+
+    exposure_id: str
+    currency_pair: str
+    notional: Decimal
+    strike: Decimal
+    tenor_days: int
+
+
+@dataclass(frozen=True)
+class MarketDataSnapshot:
+    """Container for the market data required to price an exposure."""
+
+    spot: Optional[Decimal]
+    implied_volatility: Optional[Decimal]
+    interest_rate: Optional[Decimal]
+
+    def has_all_values(self) -> bool:
+        return (
+            self.spot is not None
+            and self.implied_volatility is not None
+            and self.interest_rate is not None
+        )
+
+
+@dataclass(frozen=True)
+class PricingRequest:
+    exposure: ExposureCreated
+    spot: Decimal
+    implied_volatility: Decimal
+    interest_rate: Decimal
+    cap: Decimal
+    volatility_threshold: Decimal
+
+
+@dataclass(frozen=True)
+class QuoteComputation:
+    exposure_id: str
+    price: Decimal
+    cap: Decimal
+    implied_volatility: Decimal
+
+
+@dataclass(frozen=True)
+class Quote:
+    exposure_id: str
+    price: Decimal
+    valid_until: datetime
+    safety_buffer_seconds: int
+    cap: Decimal
+    implied_volatility: Decimal
+
+    def with_safety_buffer(self) -> "Quote":
+        """Return a quote adjusted for the configured safety buffer."""
+
+        return Quote(
+            exposure_id=self.exposure_id,
+            price=self.price,
+            valid_until=self.valid_until - timedelta(seconds=self.safety_buffer_seconds),
+            safety_buffer_seconds=self.safety_buffer_seconds,
+            cap=self.cap,
+            implied_volatility=self.implied_volatility,
+        )
+
+
+@dataclass(frozen=True)
+class QuoteReady:
+    exposure_id: str
+    price: Decimal
+    valid_until: datetime
+
+
+@dataclass(frozen=True)
+class QuoteOrchestrationResult:
+    quote: Optional[Quote] = None
+    error: Optional[str] = None
+    manual_sigma_required: bool = False
+    latency_ms: float = 0.0
+
+    def succeeded(self) -> bool:
+        return self.quote is not None and self.error is None

--- a/services/pricing-orchestrator/src/pricing_orchestrator/interfaces.py
+++ b/services/pricing-orchestrator/src/pricing_orchestrator/interfaces.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from .domain import MarketDataSnapshot, PricingRequest, QuoteComputation, QuoteReady, Quote
+
+
+class MarketDataProvider(Protocol):
+    """Fetch the market data required to price an exposure."""
+
+    def fetch(self, exposure_id: str) -> MarketDataSnapshot:
+        ...
+
+
+class PricingEngine(Protocol):
+    """Calculate a binding quote for the given pricing request."""
+
+    def price(self, request: PricingRequest) -> QuoteComputation:
+        ...
+
+
+class QuoteRepository(Protocol):
+    """Persist generated quotes."""
+
+    def save(self, quote: Quote) -> None:
+        ...
+
+
+class MessageBus(Protocol):
+    """Publish events to downstream consumers."""
+
+    def publish(self, event: QuoteReady) -> None:
+        ...
+
+
+class Clock(Protocol):
+    """Abstraction around the system clock for testability."""
+
+    def now(self):  # pragma: no cover - simple protocol definition
+        ...

--- a/services/pricing-orchestrator/src/pricing_orchestrator/orchestrator.py
+++ b/services/pricing-orchestrator/src/pricing_orchestrator/orchestrator.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from decimal import Decimal
+from time import perf_counter
+
+from .domain import (
+    ExposureCreated,
+    MarketDataSnapshot,
+    PricingRequest,
+    Quote,
+    QuoteComputation,
+    QuoteOrchestrationResult,
+    QuoteReady,
+)
+from .interfaces import Clock, MarketDataProvider, MessageBus, PricingEngine, QuoteRepository
+
+
+DEFAULT_CAP = Decimal("0.05")
+DEFAULT_VOLATILITY_THRESHOLD = Decimal("0.02")
+QUOTE_VALIDITY_SECONDS = 120
+DEFAULT_SAFETY_BUFFER_SECONDS = 5
+SLA_P99_THRESHOLD_MS = 200.0
+
+
+class MarketDataError(RuntimeError):
+    """Raised when the orchestrator cannot source required market data."""
+
+
+class SLAExceededError(RuntimeError):
+    """Raised when the orchestration runtime breaches the latency SLO."""
+
+
+@dataclass
+class QuoteOrchestrator:
+    market_data_provider: MarketDataProvider
+    pricing_engine: PricingEngine
+    quote_repository: QuoteRepository
+    message_bus: MessageBus
+    clock: Clock
+    safety_buffer_seconds: int = DEFAULT_SAFETY_BUFFER_SECONDS
+
+    def handle_exposure_created(self, event: ExposureCreated) -> QuoteOrchestrationResult:
+        """Generate a binding quote for the provided exposure."""
+
+        start = perf_counter()
+        now = self.clock.now()
+
+        try:
+            market_data = self.market_data_provider.fetch(event.exposure_id)
+        except Exception as exc:  # pragma: no cover - defensive safeguard
+            return QuoteOrchestrationResult(
+                error=f"failed to retrieve market data: {exc}",
+                manual_sigma_required=True,
+            )
+
+        if not market_data.has_all_values():
+            return QuoteOrchestrationResult(
+                error="market data incomplete - request manual sigma",
+                manual_sigma_required=True,
+            )
+
+        pricing_request = self._build_pricing_request(event, market_data)
+        computation = self.pricing_engine.price(pricing_request)
+        quote_with_validity = self._attach_validity(computation, now)
+
+        self.quote_repository.save(quote_with_validity)
+        self.message_bus.publish(
+            QuoteReady(
+                exposure_id=quote_with_validity.exposure_id,
+                price=quote_with_validity.price,
+                valid_until=quote_with_validity.valid_until,
+            )
+        )
+
+        latency_ms = (perf_counter() - start) * 1000
+        if latency_ms > SLA_P99_THRESHOLD_MS:
+            raise SLAExceededError(
+                f"Quote orchestration exceeded latency SLO: {latency_ms:.2f}ms"
+            )
+
+        return QuoteOrchestrationResult(
+            quote=quote_with_validity,
+            latency_ms=latency_ms,
+        )
+
+    def _build_pricing_request(
+        self, event: ExposureCreated, market_data: MarketDataSnapshot
+    ) -> PricingRequest:
+        implied_volatility = market_data.implied_volatility or Decimal("0")
+
+        return PricingRequest(
+            exposure=event,
+            spot=market_data.spot or Decimal("0"),
+            implied_volatility=implied_volatility,
+            interest_rate=market_data.interest_rate or Decimal("0"),
+            cap=DEFAULT_CAP,
+            volatility_threshold=DEFAULT_VOLATILITY_THRESHOLD,
+        )
+
+    def _attach_validity(self, computation: QuoteComputation, now) -> Quote:
+        valid_until = now + timedelta(seconds=QUOTE_VALIDITY_SECONDS)
+        return Quote(
+            exposure_id=computation.exposure_id,
+            price=computation.price,
+            valid_until=valid_until,
+            safety_buffer_seconds=self.safety_buffer_seconds,
+            cap=computation.cap,
+            implied_volatility=computation.implied_volatility,
+        )

--- a/services/pricing-orchestrator/tests/test_orchestrator.py
+++ b/services/pricing-orchestrator/tests/test_orchestrator.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from pricing_orchestrator.domain import (
+    ExposureCreated,
+    MarketDataSnapshot,
+    Quote,
+    QuoteComputation,
+)
+from pricing_orchestrator.orchestrator import (
+    DEFAULT_CAP,
+    DEFAULT_SAFETY_BUFFER_SECONDS,
+    QuoteOrchestrator,
+    SLAExceededError,
+)
+
+
+class FakeClock:
+    def __init__(self, now: datetime):
+        self._now = now
+
+    def now(self) -> datetime:
+        return self._now
+
+
+class FakeMarketDataProvider:
+    def __init__(self, snapshot: MarketDataSnapshot):
+        self.snapshot = snapshot
+        self.calls = []
+
+    def fetch(self, exposure_id: str) -> MarketDataSnapshot:
+        self.calls.append(exposure_id)
+        return self.snapshot
+
+
+class FakePricingEngine:
+    def __init__(self, price: Decimal):
+        self._price = price
+        self.requests = []
+
+    def price(self, request):
+        self.requests.append(request)
+        return QuoteComputation(
+            exposure_id=request.exposure.exposure_id,
+            price=self._price,
+            cap=request.cap,
+            implied_volatility=request.implied_volatility,
+        )
+
+
+class FakeQuoteRepository:
+    def __init__(self):
+        self.saved_quotes = []
+
+    def save(self, quote: Quote):
+        self.saved_quotes.append(quote)
+
+
+class FakeMessageBus:
+    def __init__(self):
+        self.events = []
+
+    def publish(self, event):
+        self.events.append(event)
+
+
+def make_exposure(exposure_id: str = "exp-1") -> ExposureCreated:
+    return ExposureCreated(
+        exposure_id=exposure_id,
+        currency_pair="EURUSD",
+        notional=Decimal("1000000"),
+        strike=Decimal("1.05"),
+        tenor_days=30,
+    )
+
+
+@pytest.fixture
+def orchestrator_dependencies():
+    now = datetime(2024, 1, 1, 12, 0, 0)
+    clock = FakeClock(now)
+    market_data = MarketDataSnapshot(
+        spot=Decimal("1.10"),
+        implied_volatility=Decimal("0.18"),
+        interest_rate=Decimal("0.02"),
+    )
+    data_provider = FakeMarketDataProvider(market_data)
+    pricing_engine = FakePricingEngine(price=Decimal("0.0125"))
+    repository = FakeQuoteRepository()
+    message_bus = FakeMessageBus()
+
+    orchestrator = QuoteOrchestrator(
+        market_data_provider=data_provider,
+        pricing_engine=pricing_engine,
+        quote_repository=repository,
+        message_bus=message_bus,
+        clock=clock,
+    )
+
+    return orchestrator, data_provider, pricing_engine, repository, message_bus, now
+
+
+def test_generates_binding_quote(orchestrator_dependencies, monkeypatch):
+    orchestrator, data_provider, pricing_engine, repository, message_bus, now = (
+        orchestrator_dependencies
+    )
+
+    monkeypatch.setattr("pricing_orchestrator.orchestrator.perf_counter", lambda: 0.0)
+    result = orchestrator.handle_exposure_created(make_exposure())
+
+    assert result.succeeded()
+    saved_quote = repository.saved_quotes[0]
+    assert saved_quote.valid_until == now + timedelta(seconds=120)
+    assert saved_quote.safety_buffer_seconds == DEFAULT_SAFETY_BUFFER_SECONDS
+    assert saved_quote.cap == DEFAULT_CAP
+    assert message_bus.events[0].exposure_id == saved_quote.exposure_id
+    assert result.quote == saved_quote
+
+
+def test_missing_market_data_requests_manual_sigma(orchestrator_dependencies, monkeypatch):
+    orchestrator, data_provider, pricing_engine, repository, message_bus, now = (
+        orchestrator_dependencies
+    )
+    data_provider.snapshot = MarketDataSnapshot(spot=None, implied_volatility=None, interest_rate=None)
+
+    monkeypatch.setattr("pricing_orchestrator.orchestrator.perf_counter", lambda: 0.0)
+    result = orchestrator.handle_exposure_created(make_exposure())
+
+    assert not result.succeeded()
+    assert result.manual_sigma_required is True
+    assert "manual sigma" in result.error.lower()
+    assert repository.saved_quotes == []
+    assert message_bus.events == []
+
+
+def test_latency_sla_violation_raises(monkeypatch, orchestrator_dependencies):
+    orchestrator, data_provider, pricing_engine, repository, message_bus, now = (
+        orchestrator_dependencies
+    )
+
+    calls = {"count": 0}
+
+    def fake_perf_counter():
+        if calls["count"] == 0:
+            calls["count"] += 1
+            return 0.0
+        return 0.25
+
+    monkeypatch.setattr("pricing_orchestrator.orchestrator.perf_counter", fake_perf_counter)
+
+    with pytest.raises(SLAExceededError):
+        orchestrator.handle_exposure_created(make_exposure())
+
+    assert repository.saved_quotes, "quote should still be persisted before SLA enforcement"
+    assert message_bus.events, "event should be emitted before SLA enforcement"


### PR DESCRIPTION
## Summary
- implement a pricing orchestrator that sources market data, drives pricing, persists quotes and emits QuoteReady events
- capture business defaults for the 5% cap at <2% volatility rule and the two minute validity window with a safety buffer
- add documentation, packaging metadata, and tests covering success, manual sigma fallbacks, and SLA breaches

## Testing
- python -m pytest services/pricing-orchestrator/tests

------
https://chatgpt.com/codex/tasks/task_e_68cc7c180798832c9fe6d40f45a56def