### PR TITLE
Add portal web quote slider flow

### DIFF
--- a/apps/portal-web/.gitignore
+++ b/apps/portal-web/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.dist
+.vite
+.DS_Store
+dist

--- a/apps/portal-web/index.html
+++ b/apps/portal-web/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Portal Quote Console</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  </head>
+  <body class="bg-canvas bg-noise text-white">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/portal-web/package.json
+++ b/apps/portal-web/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "portal-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "classnames": "^2.3.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.46",
+    "@types/react-dom": "^18.2.18",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.8"
+  }
+}

--- a/apps/portal-web/postcss.config.cjs
+++ b/apps/portal-web/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/portal-web/src/App.tsx
+++ b/apps/portal-web/src/App.tsx
@@ -1,0 +1,45 @@
+import QuoteSliderCard from './components/QuoteSliderCard';
+import SentToBankCard from './components/SentToBankCard';
+
+const App = () => {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-[#030508] via-[#05080f] to-[#07121a] text-white">
+      <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.18),_transparent_45%)]" />
+      <div className="relative z-10 mx-auto flex max-w-6xl flex-col gap-10 px-6 py-12 lg:px-12 lg:py-16">
+        <header className="space-y-3">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-emerald-400/80">Portal Invoice Flow</p>
+          <h1 className="text-4xl font-semibold tracking-tight md:text-5xl">
+            Price, send and accept FX option invoices in one motion.
+          </h1>
+          <p className="max-w-2xl text-lg text-slate-300">
+            Tune your protection with precision and hand off to banking partners instantly. The emerald desk keeps the
+            curve primed in under 120&nbsp;ms for every move.
+          </p>
+        </header>
+
+        <main className="grid gap-8 lg:grid-cols-[1.85fr,1fr]">
+          <QuoteSliderCard />
+          <div className="flex flex-col gap-6">
+            <SentToBankCard />
+            <div className="glass-panel relative overflow-hidden rounded-3xl p-6">
+              <div className="noise-overlay absolute inset-0 opacity-60" />
+              <div className="relative z-10 space-y-4">
+                <h3 className="text-xl font-semibold">Why the slider?</h3>
+                <p className="text-sm text-slate-300">
+                  Drag K to increase your knock-in coverage. The curve responds with convexity-aware premium shifts so you
+                  always see the breakeven and total invoice impact before committing.
+                </p>
+                <p className="text-sm text-slate-400">
+                  Market feeds refresh 60× a minute. Latency stays glass-smooth with GPU accelerated canvases and memoized
+                  math primitives.
+                </p>
+              </div>
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default App;

--- a/apps/portal-web/src/components/QuoteSliderCard.tsx
+++ b/apps/portal-web/src/components/QuoteSliderCard.tsx
@@ -1,0 +1,279 @@
+import { ChangeEvent, useEffect, useMemo, useState } from 'react';
+import classNames from 'classnames';
+import { fetchMarketData, MarketDataSnapshot, subscribeToMarketData } from '../services/market-data';
+import {
+  describeLatency,
+  formatCurrency,
+  formatPercent,
+  generatePremiumCurve,
+  PremiumCurvePoint,
+  priceQuote,
+  QuoteResult
+} from '../services/pricing';
+
+const DEFAULT_NOTIONAL = 5_000_000;
+const CHART_WIDTH = 420;
+const CHART_HEIGHT = 180;
+const CHART_PADDING = 18;
+
+const QuoteSliderCard = () => {
+  const [marketData, setMarketData] = useState<MarketDataSnapshot | null>(null);
+  const [quote, setQuote] = useState<QuoteResult | null>(null);
+  const [curve, setCurve] = useState<PremiumCurvePoint[]>([]);
+  const [sliderValue, setSliderValue] = useState<number>(5);
+  const [latency, setLatency] = useState<number>(0);
+
+  const handleRangeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setSliderValue(parseFloat(event.target.value));
+  };
+
+  useEffect(() => {
+    let mounted = true;
+    fetchMarketData().then((snapshot) => {
+      if (mounted) {
+        setMarketData(snapshot);
+      }
+    });
+
+    const unsubscribe = subscribeToMarketData((snapshot) => {
+      if (mounted) {
+        setMarketData(snapshot);
+      }
+    });
+
+    return () => {
+      mounted = false;
+      unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!marketData) return;
+
+    const start = performance.now();
+    const nextQuote = priceQuote({
+      marketData,
+      notional: DEFAULT_NOTIONAL,
+      strikeOffsetPct: sliderValue,
+      tenorDays: marketData.tenorDays
+    });
+    const nextCurve = generatePremiumCurve({
+      marketData,
+      tenorDays: marketData.tenorDays,
+      notional: DEFAULT_NOTIONAL,
+      min: 0,
+      max: 10,
+      resolution: 31
+    });
+    const duration = performance.now() - start;
+
+    setQuote(nextQuote);
+    setCurve(nextCurve);
+    setLatency(duration);
+  }, [marketData, sliderValue]);
+
+  const selectedPoint = useMemo(() => {
+    if (!curve.length) return null;
+    return (
+      curve.find((point) => Math.abs(point.offset - sliderValue) < 0.001) ??
+      curve.reduce((closest, point) => {
+        const currentDelta = Math.abs(point.offset - sliderValue);
+        const bestDelta = Math.abs(closest.offset - sliderValue);
+        return currentDelta < bestDelta ? point : closest;
+      })
+    );
+  }, [curve, sliderValue]);
+
+  const sparkline = useMemo(() => buildCurvePath(curve), [curve]);
+  const highlight = useMemo(() => {
+    if (!curve.length || !selectedPoint) return null;
+    const { x, y } = projectPoint(selectedPoint, curve);
+    return { x, y };
+  }, [curve, selectedPoint]);
+
+  if (!marketData || !quote) {
+    return (
+      <section className="glass-panel relative overflow-hidden rounded-3xl p-8 shadow-glow">
+        <div className="noise-overlay absolute inset-0 opacity-60" />
+        <div className="relative z-10 space-y-6">
+          <div className="flex items-center gap-3 text-sm text-slate-300">
+            <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-400" />
+            Priming invoice engine…
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="glass-panel relative overflow-hidden rounded-3xl p-8 shadow-glow">
+      <div className="noise-overlay absolute inset-0 opacity-60" />
+      <div className="relative z-10 flex flex-col gap-8">
+        <header className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+          <div className="space-y-5">
+            <div className="flex flex-wrap gap-2">
+              <Badge>FX Option</Badge>
+              <Badge>{`${marketData.tenorDays} day tenor`}</Badge>
+              <Badge>USD → EUR</Badge>
+            </div>
+            <div>
+              <h2 className="text-3xl font-semibold">Invoice premium calibrator</h2>
+              <p className="max-w-xl text-sm text-slate-300">
+                Slide K to dial protection. We keep the premium curve responsive under 120&nbsp;ms while displaying the
+                breakeven against the live forward.
+              </p>
+            </div>
+          </div>
+          <div className="rounded-2xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-right text-xs uppercase tracking-[0.35em] text-emerald-200">
+            <span className="block text-[0.65rem] text-emerald-300/80">latency</span>
+            <span className="text-base font-semibold tracking-tight text-emerald-100">
+              {latency.toFixed(1)} ms
+            </span>
+            <span className="block text-[0.65rem] text-emerald-300/60">{describeLatency(latency)}</span>
+          </div>
+        </header>
+
+        <div className="grid gap-6 lg:grid-cols-[1.4fr,1fr]">
+          <div className="flex flex-col gap-6">
+            <div className="rounded-3xl border border-white/5 bg-white/5 p-6">
+              <div className="flex items-center justify-between text-sm text-slate-300">
+                <span className="font-medium text-white">K offset</span>
+                <span>{sliderValue.toFixed(1)}%</span>
+              </div>
+              <div className="mt-6">
+                <input
+                  type="range"
+                  min={0}
+                  max={10}
+                  step={0.5}
+                  value={sliderValue}
+                  onChange={handleRangeChange}
+                  onInput={handleRangeChange}
+                  className="h-2 w-full appearance-none rounded-full bg-slate-800 accent-emerald-400"
+                />
+                <div className="relative -mt-2 h-2 w-full overflow-hidden rounded-full">
+                  <div
+                    className="absolute inset-0 h-full rounded-full bg-gradient-to-r from-emerald-500 via-emerald-400 to-emerald-300"
+                    style={{ width: `${Math.min(100, Math.max(6, (sliderValue / 10) * 100))}%` }}
+                  />
+                </div>
+              </div>
+              <div className="mt-3 flex justify-between text-xs text-slate-500">
+                <span>0%</span>
+                <span>10%</span>
+              </div>
+            </div>
+
+            <div className="relative overflow-hidden rounded-3xl border border-white/5 bg-gradient-to-br from-white/5 via-white/2 to-white/5 p-6">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-emerald-200">premium curve</h3>
+                <span className="text-xs text-slate-300">{curve.length} samples</span>
+              </div>
+              <svg
+                className="mt-4 w-full"
+                viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+                role="img"
+                aria-label="Premium curve"
+              >
+                <defs>
+                  <linearGradient id="curveFill" x1="0" x2="0" y1="0" y2="1">
+                    <stop offset="0%" stopColor="rgba(16,185,129,0.35)" />
+                    <stop offset="100%" stopColor="rgba(16,185,129,0)" />
+                  </linearGradient>
+                </defs>
+                {sparkline && (
+                  <>
+                    <path d={`${sparkline} L ${CHART_WIDTH - CHART_PADDING} ${CHART_HEIGHT - CHART_PADDING} L ${CHART_PADDING} ${CHART_HEIGHT - CHART_PADDING} Z`} fill="url(#curveFill)" opacity={0.5} />
+                    <path d={sparkline} fill="none" stroke="url(#curveFill)" strokeWidth={3} />
+                  </>
+                )}
+                {highlight && (
+                  <g>
+                    <circle cx={highlight.x} cy={highlight.y} r={6} fill="#10b981" stroke="rgba(255,255,255,0.8)" strokeWidth={2} />
+                    <line
+                      x1={highlight.x}
+                      x2={highlight.x}
+                      y1={highlight.y}
+                      y2={CHART_HEIGHT - CHART_PADDING}
+                      stroke="rgba(148,163,184,0.4)"
+                      strokeDasharray="4 6"
+                    />
+                  </g>
+                )}
+              </svg>
+            </div>
+          </div>
+
+          <div className="flex flex-col justify-between gap-5 rounded-3xl border border-white/5 bg-white/5 p-6">
+            <div className="space-y-4">
+              <div>
+                <p className="text-xs uppercase tracking-[0.3em] text-emerald-200">premium</p>
+                <p className="text-4xl font-semibold text-white">{formatPercent(quote.premiumPct)}</p>
+              </div>
+              <div className="grid gap-3 text-sm text-slate-300">
+                <InfoRow label="Total premium" value={formatCurrency(quote.premiumAmount)} />
+                <InfoRow label="Forward rate" value={quote.forwardRate.toFixed(4)} />
+                <InfoRow label="Breakeven" value={quote.breakEvenRate.toFixed(4)} />
+              </div>
+            </div>
+            <button
+              type="button"
+              className={classNames(
+                'group relative overflow-hidden rounded-2xl border border-emerald-400/60 bg-emerald-500/20 px-6 py-4 text-lg font-semibold text-emerald-100 shadow-glow transition-transform duration-200',
+                'hover:-translate-y-0.5 hover:shadow-[0_0_40px_rgba(16,185,129,0.4)]'
+              )}
+            >
+              <span className="relative z-10">Get Started</span>
+              <span className="absolute inset-0 z-0 bg-gradient-to-r from-emerald-500 via-emerald-400 to-emerald-600 opacity-0 transition-opacity duration-200 group-hover:opacity-90" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+const Badge = ({ children }: { children: string }) => (
+  <span className="rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-200">
+    {children}
+  </span>
+);
+
+const InfoRow = ({ label, value }: { label: string; value: string }) => (
+  <div className="flex items-center justify-between">
+    <span className="text-xs uppercase tracking-[0.3em] text-slate-500">{label}</span>
+    <span className="text-base text-white">{value}</span>
+  </div>
+);
+
+function buildCurvePath(points: PremiumCurvePoint[]) {
+  if (!points.length) return '';
+  const min = Math.min(...points.map((p) => p.premiumPct));
+  const max = Math.max(...points.map((p) => p.premiumPct));
+  const range = max - min || 1;
+
+  return points
+    .map((point, index) => {
+      const { x, y } = project(point, index, points.length, min, range);
+      return `${index === 0 ? 'M' : 'L'} ${x} ${y}`;
+    })
+    .join(' ');
+}
+
+function project(point: PremiumCurvePoint, index: number, length: number, min: number, range: number) {
+  const xProgress = length <= 1 ? 0 : index / (length - 1);
+  const yProgress = (point.premiumPct - min) / range;
+  const x = CHART_PADDING + xProgress * (CHART_WIDTH - CHART_PADDING * 2);
+  const y = CHART_HEIGHT - CHART_PADDING - yProgress * (CHART_HEIGHT - CHART_PADDING * 2);
+  return { x, y };
+}
+
+function projectPoint(target: PremiumCurvePoint, points: PremiumCurvePoint[]) {
+  const min = Math.min(...points.map((p) => p.premiumPct));
+  const max = Math.max(...points.map((p) => p.premiumPct));
+  const range = max - min || 1;
+  const index = points.findIndex((point) => point === target);
+  return project(target, index === -1 ? 0 : index, points.length, min, range);
+}
+
+export default QuoteSliderCard;

--- a/apps/portal-web/src/components/SentToBankCard.tsx
+++ b/apps/portal-web/src/components/SentToBankCard.tsx
@@ -1,0 +1,63 @@
+const RECENT_ACTIVITY = [
+  {
+    bank: 'Emerald National',
+    timestamp: '2m ago',
+    currencyPair: 'USD → EUR',
+    premiumPct: 1.62,
+    status: 'Awaiting confirmation'
+  },
+  {
+    bank: 'Helios Partners',
+    timestamp: '18m ago',
+    currencyPair: 'GBP → USD',
+    premiumPct: 1.94,
+    status: 'Sent to bank'
+  },
+  {
+    bank: 'Zürich Clearing',
+    timestamp: '39m ago',
+    currencyPair: 'SGD → JPY',
+    premiumPct: 2.11,
+    status: 'Settled'
+  }
+];
+
+const SentToBankCard = () => {
+  return (
+    <section className="glass-panel relative overflow-hidden rounded-3xl p-6 shadow-lg">
+      <div className="noise-overlay absolute inset-0 opacity-60" />
+      <div className="relative z-10 flex flex-col gap-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm uppercase tracking-[0.2em] text-emerald-400/60">sent to bank</p>
+            <h2 className="text-2xl font-semibold">Recent handoffs</h2>
+          </div>
+          <span className="rounded-full border border-emerald-500/60 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-300">
+            Auto-tracked
+          </span>
+        </div>
+
+        <div className="space-y-4">
+          {RECENT_ACTIVITY.map((activity) => (
+            <article
+              key={`${activity.bank}-${activity.timestamp}`}
+              className="flex items-center justify-between rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-sm text-slate-200"
+            >
+              <div className="space-y-1">
+                <p className="font-medium text-white">{activity.bank}</p>
+                <p className="text-xs uppercase tracking-[0.28em] text-slate-400">{activity.timestamp}</p>
+              </div>
+              <div className="text-right">
+                <p className="font-semibold text-emerald-300">{activity.currencyPair}</p>
+                <p className="text-xs text-slate-400">Premium {activity.premiumPct.toFixed(2)}%</p>
+                <p className="text-xs text-emerald-200/80">{activity.status}</p>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default SentToBankCard;

--- a/apps/portal-web/src/main.tsx
+++ b/apps/portal-web/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles/index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/portal-web/src/services/market-data.ts
+++ b/apps/portal-web/src/services/market-data.ts
@@ -1,0 +1,55 @@
+export interface MarketDataSnapshot {
+  spotRate: number;
+  tenorDays: number;
+  volatility: number;
+  domesticRate: number;
+  foreignRate: number;
+  timestamp: number;
+}
+
+const BASE_SNAPSHOT: MarketDataSnapshot = {
+  spotRate: 1.0875,
+  tenorDays: 45,
+  volatility: 0.14,
+  domesticRate: 0.048,
+  foreignRate: 0.018,
+  timestamp: Date.now()
+};
+
+type Listener = (snapshot: MarketDataSnapshot) => void;
+
+const listeners = new Set<Listener>();
+
+function jitter(value: number, intensity: number) {
+  return value + (Math.random() - 0.5) * intensity;
+}
+
+export async function fetchMarketData(): Promise<MarketDataSnapshot> {
+  return new Promise((resolve) => {
+    window.requestAnimationFrame(() => {
+      resolve({ ...BASE_SNAPSHOT, timestamp: Date.now() });
+    });
+  });
+}
+
+export function subscribeToMarketData(listener: Listener) {
+  listeners.add(listener);
+  listener({ ...BASE_SNAPSHOT, timestamp: Date.now() });
+
+  const interval = window.setInterval(() => {
+    const next: MarketDataSnapshot = {
+      spotRate: jitter(BASE_SNAPSHOT.spotRate, 0.0008),
+      tenorDays: BASE_SNAPSHOT.tenorDays,
+      volatility: Math.max(0.1, jitter(BASE_SNAPSHOT.volatility, 0.01)),
+      domesticRate: Math.max(0.03, jitter(BASE_SNAPSHOT.domesticRate, 0.002)),
+      foreignRate: Math.max(0.012, jitter(BASE_SNAPSHOT.foreignRate, 0.002)),
+      timestamp: Date.now()
+    };
+    listeners.forEach((cb) => cb(next));
+  }, 5000);
+
+  return () => {
+    window.clearInterval(interval);
+    listeners.delete(listener);
+  };
+}

--- a/apps/portal-web/src/services/pricing.ts
+++ b/apps/portal-web/src/services/pricing.ts
@@ -1,0 +1,97 @@
+import { MarketDataSnapshot } from './market-data';
+
+export interface QuoteRequest {
+  notional: number;
+  strikeOffsetPct: number;
+  tenorDays: number;
+  marketData: MarketDataSnapshot;
+}
+
+export interface QuoteResult {
+  premiumPct: number;
+  premiumAmount: number;
+  forwardRate: number;
+  breakEvenRate: number;
+}
+
+export interface PremiumCurvePoint {
+  offset: number;
+  premiumPct: number;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function priceQuote(request: QuoteRequest): QuoteResult {
+  const { marketData, strikeOffsetPct, tenorDays, notional } = request;
+
+  const coverageRatio = 1 + strikeOffsetPct / 100;
+  const forwardCarry = (marketData.domesticRate - marketData.foreignRate) * (tenorDays / 360);
+  const forwardRate = marketData.spotRate * (1 + forwardCarry);
+
+  const tenorScale = Math.sqrt(tenorDays / 365);
+  const basePremium = 0.01 + marketData.volatility * 0.035;
+  const markup = strikeOffsetPct * 0.00045;
+  const convexity = Math.pow(strikeOffsetPct - 4.5, 2) * 0.00009 * (1 + tenorScale * 0.3);
+
+  const premiumRatio = clamp((basePremium + markup + convexity) * coverageRatio, 0.005, 0.032);
+  const premiumPct = +(premiumRatio * 100).toFixed(2);
+  const premiumAmount = +(notional * premiumRatio).toFixed(2);
+  const breakEvenRate = +(forwardRate * (1 + premiumRatio)).toFixed(6);
+
+  return {
+    premiumPct,
+    premiumAmount,
+    forwardRate: +forwardRate.toFixed(6),
+    breakEvenRate
+  };
+}
+
+interface CurveOptions {
+  marketData: MarketDataSnapshot;
+  tenorDays: number;
+  notional: number;
+  resolution?: number;
+  min?: number;
+  max?: number;
+}
+
+export function generatePremiumCurve({
+  marketData,
+  tenorDays,
+  notional,
+  resolution = 21,
+  min = 0,
+  max = 10
+}: CurveOptions): PremiumCurvePoint[] {
+  const step = (max - min) / (resolution - 1);
+  const points: PremiumCurvePoint[] = [];
+
+  for (let i = 0; i < resolution; i += 1) {
+    const offset = +(min + step * i).toFixed(2);
+    const quote = priceQuote({ marketData, tenorDays, notional, strikeOffsetPct: offset });
+    points.push({ offset, premiumPct: quote.premiumPct });
+  }
+
+  return points;
+}
+
+export function formatCurrency(value: number) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: value >= 1000 ? 0 : 2
+  }).format(value);
+}
+
+export function formatPercent(value: number) {
+  return `${value.toFixed(2)}%`;
+}
+
+export function describeLatency(latency: number) {
+  if (latency < 40) return 'instant';
+  if (latency < 80) return 'snappy';
+  if (latency < 120) return 'desk-ready';
+  return 'review';
+}

--- a/apps/portal-web/src/styles/index.css
+++ b/apps/portal-web/src/styles/index.css
@@ -1,0 +1,71 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color-scheme: dark;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background-color: theme('colors.canvas');
+}
+
+input[type='range'] {
+  width: 100%;
+  background: transparent;
+}
+
+input[type='range']::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 9999px;
+  background: theme('colors.emerald.400');
+  border: 2px solid rgba(236, 253, 245, 0.9);
+  box-shadow: 0 0 0 8px rgba(16, 185, 129, 0.2);
+}
+
+input[type='range']::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 9999px;
+  background: theme('colors.emerald.400');
+  border: 2px solid rgba(236, 253, 245, 0.9);
+  box-shadow: 0 0 0 8px rgba(16, 185, 129, 0.2);
+}
+
+input[type='range']::-webkit-slider-runnable-track {
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: rgba(15, 23, 42, 0.8);
+}
+
+input[type='range']::-moz-range-track {
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: rgba(15, 23, 42, 0.8);
+}
+
+.glass-panel {
+  backdrop-filter: blur(24px);
+  background: rgba(9, 14, 20, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.noise-overlay {
+  position: relative;
+}
+
+.noise-overlay::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  mix-blend-mode: soft-light;
+  opacity: 0.4;
+  background-image: theme('backgroundImage.noise');
+}

--- a/apps/portal-web/tailwind.config.cjs
+++ b/apps/portal-web/tailwind.config.cjs
@@ -1,0 +1,24 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        canvas: '#04050a',
+        emerald: {
+          400: '#34d399',
+          500: '#10b981',
+          600: '#059669'
+        }
+      },
+      boxShadow: {
+        glow: '0 0 25px rgba(16, 185, 129, 0.45)'
+      },
+      backgroundImage: {
+        noise: "url('data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'120\' height=\'120\' viewBox=\'0 0 120 120\'%3E%3Cfilter id=\'n\'%3E%3CfeTurbulence type=\'fractalNoise\' baseFrequency=\'0.9\' numOctaves=\'4\' stitchTiles=\'stitch\'/%3E%3C/filter%3E%3Crect width=\'120\' height=\'120\' filter=\'url(%23n)\' opacity=\'0.12\'/%3E%3C/svg%3E')"
+      }
+    }
+  },
+  plugins: []
+};

--- a/apps/portal-web/tsconfig.json
+++ b/apps/portal-web/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/apps/portal-web/tsconfig.node.json
+++ b/apps/portal-web/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/portal-web/vite.config.ts
+++ b/apps/portal-web/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    target: 'esnext'
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a portal web app with Vite/React and Tailwind-driven dark emerald styling
- implement a QuoteSliderCard that streams mock market data, prices invoices, and renders a premium curve with a K slider and CTA
- add a glassmorphic “Sent to bank” card showcasing recent transactions and supporting services/utilities

## Testing
- npm run build *(fails: npm could not download required packages because registry access returned HTTP 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7c23dd48832c89d16ea091346e8e