### PR TITLE
Add risk service for weekly bucketing and execution planning

### DIFF
--- a/services/risk/__init__.py
+++ b/services/risk/__init__.py
@@ -1,0 +1,4 @@
+from .models import Exposure, Hedge, Quote
+from .service import RiskService
+
+__all__ = ["Exposure", "Hedge", "Quote", "RiskService"]

--- a/services/risk/bucketing.py
+++ b/services/risk/bucketing.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from typing import Dict, Iterable, Mapping, MutableMapping, Tuple
+
+from .models import Exposure, Hedge, Quote
+
+
+@dataclass
+class _Aggregate:
+    delta: float = 0.0
+    weight: float = 0.0
+    weighted_days: float = 0.0
+    distribution: Counter = field(default_factory=Counter)
+
+    def add(self, position: Exposure | Hedge, valuation_date: date) -> None:
+        signed = position.signed_delta()
+        self.delta += signed
+
+        weight = abs(signed)
+        self.weight += weight
+
+        days = max((position.expiry - valuation_date).days, 0)
+        self.weighted_days += weight * days
+
+        for strike, ratio in position.distribution().items():
+            self.distribution[strike] += weight * ratio
+
+    def average_days(self, default: int = 7) -> int:
+        if self.weight == 0:
+            return default
+        return int(round(self.weighted_days / self.weight))
+
+    def normalised_distribution(self) -> Dict[str, float]:
+        if not self.distribution:
+            return {"ATM": 1.0}
+        total = sum(self.distribution.values())
+        if total <= 0:
+            return {"ATM": 1.0}
+        return {key: value / total for key, value in self.distribution.items()}
+
+
+@dataclass
+class BucketMetrics:
+    pair: str
+    week_start: date
+    week_end: date
+    pre_delta: float
+    post_delta: float
+    pre_var: float
+    post_var: float
+    distribution: Dict[str, float]
+
+
+def week_bounds(target_date: date) -> Tuple[date, date]:
+    start = target_date - timedelta(days=target_date.weekday())
+    end = start + timedelta(days=6)
+    return start, end
+
+
+def _aggregate_positions(
+    positions: Iterable[Exposure | Hedge],
+    valuation_date: date,
+) -> MutableMapping[Tuple[str, date], _Aggregate]:
+    buckets: MutableMapping[Tuple[str, date], _Aggregate] = defaultdict(_Aggregate)
+    for position in positions:
+        week_start, _ = week_bounds(position.expiry)
+        buckets[(position.pair, week_start)].add(position, valuation_date)
+    return buckets
+
+
+def build_bucket_metrics(
+    exposures: Iterable[Exposure],
+    hedges: Iterable[Hedge],
+    quotes: Mapping[str, Quote],
+    valuation_date: date,
+) -> Dict[Tuple[str, date], BucketMetrics]:
+    exposure_data = _aggregate_positions(exposures, valuation_date)
+    hedge_data = _aggregate_positions(hedges, valuation_date)
+
+    all_keys = set(exposure_data) | set(hedge_data)
+    metrics: Dict[Tuple[str, date], BucketMetrics] = {}
+
+    for pair, week_start in sorted(all_keys):
+        exposure_bucket = exposure_data.get((pair, week_start), _Aggregate())
+        hedge_bucket = hedge_data.get((pair, week_start), _Aggregate())
+
+        week_end = week_start + timedelta(days=6)
+        quote = quotes.get(pair)
+
+        pre_delta = exposure_bucket.delta
+        post_delta = pre_delta + hedge_bucket.delta
+
+        avg_days_exposure = exposure_bucket.average_days()
+        avg_days_combined = _blended_average_days(exposure_bucket, hedge_bucket)
+
+        pre_var = _compute_var(quote, pre_delta, avg_days_exposure)
+        post_var = _compute_var(quote, post_delta, avg_days_combined)
+
+        distribution = exposure_bucket.normalised_distribution()
+        if exposure_bucket.weight == 0 and hedge_bucket.weight > 0:
+            distribution = hedge_bucket.normalised_distribution()
+
+        metrics[(pair, week_start)] = BucketMetrics(
+            pair=pair,
+            week_start=week_start,
+            week_end=week_end,
+            pre_delta=pre_delta,
+            post_delta=post_delta,
+            pre_var=pre_var,
+            post_var=post_var,
+            distribution=distribution,
+        )
+
+    return metrics
+
+
+def _compute_var(quote: Quote | None, delta: float, days: int) -> float:
+    if quote is None:
+        return 0.0
+    return quote.simple_var(delta, days)
+
+
+def _blended_average_days(exposure_bucket: _Aggregate, hedge_bucket: _Aggregate) -> int:
+    total_weight = exposure_bucket.weight + hedge_bucket.weight
+    if total_weight == 0:
+        return 7
+    combined_days = exposure_bucket.weighted_days + hedge_bucket.weighted_days
+    return int(round(combined_days / total_weight))

--- a/services/risk/models.py
+++ b/services/risk/models.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class Quote:
+    """Market data quote used for risk metrics."""
+
+    pair: str
+    spot: float
+    volatility: float
+
+    def simple_var(self, delta: float, days: int) -> float:
+        """Return a very simple value-at-risk approximation.
+
+        The method treats ``volatility`` as an annualised percentage move and
+        scales it by the square root of time (in trading days).
+        """
+
+        if self.spot <= 0:
+            raise ValueError("Spot must be positive to compute VaR.")
+        if self.volatility < 0:
+            raise ValueError("Volatility cannot be negative.")
+
+        if days <= 0:
+            # If the option is effectively expired, treat it as a one day move so
+            # the caller still receives a non-zero risk number.
+            time_scale = 1.0 / 252.0
+        else:
+            time_scale = days / 252.0
+        return abs(delta) * self.spot * self.volatility * time_scale ** 0.5
+
+
+@dataclass(frozen=True)
+class Position:
+    """Base representation for exposures and hedges."""
+
+    pair: str
+    expiry: date
+    side: str
+    delta: float
+    k_distribution: Dict[str, float] = field(default_factory=dict)
+
+    def signed_delta(self) -> float:
+        sign = 1.0 if self.side.lower() in {"buy", "long"} else -1.0
+        return sign * self.delta
+
+    def distribution(self) -> Dict[str, float]:
+        if not self.k_distribution:
+            return {"ATM": 1.0}
+        total = sum(self.k_distribution.values())
+        if total <= 0:
+            return {"ATM": 1.0}
+        return {key: value / total for key, value in self.k_distribution.items()}
+
+
+class Exposure(Position):
+    """Risk exposure that still needs to be managed."""
+
+
+class Hedge(Position):
+    """Existing hedge applied to an exposure."""

--- a/services/risk/service.py
+++ b/services/risk/service.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from datetime import date, datetime
+from typing import Iterable, List, Mapping, Sequence
+
+from .bucketing import BucketMetrics, build_bucket_metrics
+from .models import Exposure, Hedge, Position, Quote
+
+
+class RiskService:
+    """Produce risk buckets, savings from netting, and an execution plan."""
+
+    def __init__(
+        self,
+        quotes: Sequence[Quote | Mapping[str, float]],
+        valuation_date: date | None = None,
+    ) -> None:
+        self.valuation_date = valuation_date or date.today()
+        self.quotes = {quote.pair: quote for quote in self._coerce_quotes(quotes)}
+
+    def generate_plan(
+        self,
+        exposures: Iterable[Exposure | Mapping[str, object]],
+        hedges: Iterable[Hedge | Mapping[str, object]],
+    ) -> dict:
+        """Create the full risk plan summary."""
+
+        exposure_models = [self._coerce_position(item, Exposure) for item in exposures]
+        hedge_models = [self._coerce_position(item, Hedge) for item in hedges]
+
+        metrics = build_bucket_metrics(
+            exposure_models, hedge_models, self.quotes, self.valuation_date
+        )
+        plan = self._build_execution_list(metrics)
+
+        return {
+            "buckets": [self._serialise_bucket(metric) for metric in metrics.values()],
+            "execution_plan": plan,
+            "netting_savings": self._compute_savings(metrics),
+        }
+
+    def plan_as_json(
+        self,
+        exposures: Iterable[Exposure | Mapping[str, object]],
+        hedges: Iterable[Hedge | Mapping[str, object]],
+    ) -> str:
+        """Render the plan as JSON for the admin interface."""
+
+        plan = self.generate_plan(exposures, hedges)
+        return json.dumps(plan, default=_json_default, indent=2, sort_keys=True)
+
+    def display_netting_savings(
+        self,
+        exposures: Iterable[Exposure | Mapping[str, object]],
+        hedges: Iterable[Hedge | Mapping[str, object]],
+    ) -> str:
+        """Return a formatted view of the savings from netting."""
+
+        summary = self.generate_plan(exposures, hedges)
+        savings = summary["netting_savings"]
+        return (
+            "Netting saved {delta:.2f} delta units and {var:.2f} VaR units.".format(
+                delta=savings["delta"],
+                var=savings["var"],
+            )
+        )
+
+    def _build_execution_list(self, metrics: Mapping[tuple, BucketMetrics]) -> List[dict]:
+        plan: List[dict] = []
+        for metric in metrics.values():
+            residual = metric.post_delta
+            if abs(residual) < 1e-9:
+                continue
+            side = "sell" if residual > 0 else "buy"
+            plan.append(
+                {
+                    "pair": metric.pair,
+                    "expiry": metric.week_end.isoformat(),
+                    "side": side,
+                    "qty": abs(residual),
+                    "k_distribution": metric.distribution,
+                }
+            )
+        return plan
+
+    def _compute_savings(self, metrics: Mapping[tuple, BucketMetrics]) -> dict:
+        pre_delta = sum(abs(metric.pre_delta) for metric in metrics.values())
+        post_delta = sum(abs(metric.post_delta) for metric in metrics.values())
+
+        pre_var = sum(metric.pre_var for metric in metrics.values())
+        post_var = sum(metric.post_var for metric in metrics.values())
+
+        return {
+            "delta": pre_delta - post_delta,
+            "var": pre_var - post_var,
+        }
+
+    def _coerce_quotes(
+        self, quotes: Sequence[Quote | Mapping[str, float]]
+    ) -> List[Quote]:
+        parsed: List[Quote] = []
+        for item in quotes:
+            if isinstance(item, Quote):
+                parsed.append(item)
+                continue
+            parsed.append(
+                Quote(
+                    pair=str(item["pair"]),
+                    spot=float(item["spot"]),
+                    volatility=float(item["volatility"]),
+                )
+            )
+        return parsed
+
+    def _coerce_position(
+        self, item: Position | Mapping[str, object], cls: type[Position]
+    ) -> Position:
+        if isinstance(item, cls):
+            return item
+        expiry = item.get("expiry")  # type: ignore[index]
+        if isinstance(expiry, str):
+            expiry_date = date.fromisoformat(expiry)
+        elif isinstance(expiry, datetime):
+            expiry_date = expiry.date()
+        elif isinstance(expiry, date):
+            expiry_date = expiry
+        else:
+            raise TypeError("expiry must be a date or ISO formatted string")
+
+        distribution = item.get("k_distribution") if isinstance(item, Mapping) else None
+        if distribution is None:
+            distribution = {}
+        return cls(  # type: ignore[call-arg]
+            pair=str(item["pair"]),  # type: ignore[index]
+            expiry=expiry_date,
+            side=str(item.get("side", "buy")),  # type: ignore[arg-type]
+            delta=float(item.get("delta") or item.get("qty") or 0.0),  # type: ignore[index]
+            k_distribution=dict(distribution),
+        )
+
+    def _serialise_bucket(self, metric: BucketMetrics) -> dict:
+        data = asdict(metric)
+        data["week_start"] = metric.week_start.isoformat()
+        data["week_end"] = metric.week_end.isoformat()
+        return data
+
+
+def _json_default(value):
+    if isinstance(value, date):
+        return value.isoformat()
+    raise TypeError(f"Object of type {type(value)!r} is not JSON serialisable")

--- a/tests/test_risk_service.py
+++ b/tests/test_risk_service.py
@@ -1,0 +1,101 @@
+from datetime import date
+
+import pytest
+
+from services.risk import RiskService
+
+
+@pytest.fixture
+def sample_quotes():
+    return [
+        {"pair": "EURUSD", "spot": 1.09, "volatility": 0.12},
+        {"pair": "GBPUSD", "spot": 1.24, "volatility": 0.15},
+    ]
+
+
+def test_generate_plan_creates_weekly_buckets(sample_quotes):
+    valuation_date = date(2024, 1, 5)
+    service = RiskService(sample_quotes, valuation_date=valuation_date)
+
+    exposures = [
+        {
+            "pair": "EURUSD",
+            "expiry": date(2024, 1, 10),
+            "side": "buy",
+            "delta": 5.0,
+            "k_distribution": {"25D": 0.5, "ATM": 0.5},
+        },
+        {
+            "pair": "EURUSD",
+            "expiry": date(2024, 1, 12),
+            "side": "sell",
+            "delta": 2.0,
+        },
+        {
+            "pair": "GBPUSD",
+            "expiry": date(2024, 1, 16),
+            "side": "buy",
+            "delta": 4.0,
+        },
+    ]
+
+    hedges = [
+        {
+            "pair": "EURUSD",
+            "expiry": date(2024, 1, 11),
+            "side": "sell",
+            "delta": 1.0,
+        },
+        {
+            "pair": "GBPUSD",
+            "expiry": date(2024, 1, 17),
+            "side": "sell",
+            "delta": 4.0,
+        },
+    ]
+
+    plan = service.generate_plan(exposures, hedges)
+
+    eurusd_bucket = next(
+        bucket for bucket in plan["buckets"] if bucket["pair"] == "EURUSD"
+    )
+    assert eurusd_bucket["week_start"] == "2024-01-08"
+    assert eurusd_bucket["week_end"] == "2024-01-14"
+    assert pytest.approx(eurusd_bucket["pre_delta"], rel=1e-6) == 3.0
+    assert pytest.approx(eurusd_bucket["post_delta"], rel=1e-6) == 2.0
+
+    # Pre and post VaR should be positive and the hedge should reduce it.
+    assert eurusd_bucket["pre_var"] > 0
+    assert eurusd_bucket["post_var"] < eurusd_bucket["pre_var"]
+
+    execution_items = plan["execution_plan"]
+    assert len(execution_items) == 1
+    instruction = execution_items[0]
+    assert instruction["pair"] == "EURUSD"
+    assert instruction["expiry"] == "2024-01-14"
+    assert instruction["side"] == "sell"
+    assert pytest.approx(instruction["qty"], rel=1e-6) == 2.0
+
+    distribution = instruction["k_distribution"]
+    assert pytest.approx(distribution["25D"], rel=1e-3) == 0.3571428
+    assert pytest.approx(distribution["ATM"], rel=1e-3) == 0.6428571
+    assert pytest.approx(sum(distribution.values()), rel=1e-6) == 1.0
+
+    savings = plan["netting_savings"]
+    assert savings["delta"] > 0
+    assert savings["var"] > 0
+
+
+def test_json_plan_and_display(sample_quotes):
+    service = RiskService(sample_quotes, valuation_date=date(2024, 1, 5))
+    exposures = [
+        {"pair": "EURUSD", "expiry": "2024-01-10", "side": "buy", "delta": 1.0},
+    ]
+    hedges = []
+
+    json_plan = service.plan_as_json(exposures, hedges)
+    assert "\n" in json_plan
+    assert "EURUSD" in json_plan
+
+    display = service.display_netting_savings(exposures, hedges)
+    assert "Netting saved" in display


### PR DESCRIPTION
## Summary
- add models for quotes, exposures, and hedges to support delta-aware calculations
- compute weekly currency buckets with pre/post delta, VaR, and strike distributions
- expose a risk service that outputs execution instructions, savings text, and JSON views with test coverage

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc7c6c9dc0832c948bdc2a3dfd5d95