### PR TITLE
feat: add admin control room app

### DIFF
--- a/apps/admin/.eslintrc.json
+++ b/apps/admin/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next", "next/core-web-vitals"]
+}

--- a/apps/admin/app/(auth)/layout.tsx
+++ b/apps/admin/app/(auth)/layout.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+
+export default function AuthLayout({
+  children
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100 flex items-center justify-center p-6">
+      <div className="w-full max-w-md space-y-6">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/app/(auth)/login/page.tsx
+++ b/apps/admin/app/(auth)/login/page.tsx
@@ -1,0 +1,23 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+import { LoginForm } from '@/components/LoginForm';
+import { SESSION_COOKIE_NAME, verifySessionToken } from '@/lib/auth';
+
+export default function LoginPage() {
+  const token = cookies().get(SESSION_COOKIE_NAME)?.value;
+  const session = verifySessionToken(token);
+
+  if (session) {
+    redirect('/');
+  }
+
+  return (
+    <>
+      <LoginForm />
+      <p className="text-center text-xs text-slate-500">
+        Trouble signing in? Contact the trading operations lead to rotate your hardware token.
+      </p>
+    </>
+  );
+}

--- a/apps/admin/app/(dashboard)/audit/page.tsx
+++ b/apps/admin/app/(dashboard)/audit/page.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { auditLog } from '@/lib/data';
+import { formatDate } from '@/lib/format';
+
+export default function AuditPage() {
+  const [query, setQuery] = useState('');
+  const [actor, setActor] = useState<string>('All users');
+  const [entity, setEntity] = useState<string>('All entities');
+
+  const actors = useMemo(() => ['All users', ...new Set(auditLog.map((entry) => entry.actor))], []);
+  const entities = useMemo(() => ['All entities', ...new Set(auditLog.map((entry) => entry.entity))], []);
+
+  const filtered = useMemo(() => {
+    return auditLog.filter((entry) => {
+      const matchesQuery = `${entry.action} ${entry.metadata} ${entry.ip}`
+        .toLowerCase()
+        .includes(query.toLowerCase());
+      const matchesActor = actor === 'All users' || entry.actor === actor;
+      const matchesEntity = entity === 'All entities' || entry.entity === entity;
+      return matchesQuery && matchesActor && matchesEntity;
+    });
+  }, [actor, entity, query]);
+
+  return (
+    <div className="space-y-6">
+      <div className="section-card space-y-4">
+        <div className="filter-bar">
+          <input
+            type="search"
+            placeholder="Search audit trail"
+            className="search-input"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+          <select className="filter-pill" value={actor} onChange={(event) => setActor(event.target.value)}>
+            {actors.map((value) => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
+          </select>
+          <select className="filter-pill" value={entity} onChange={(event) => setEntity(event.target.value)}>
+            {entities.map((value) => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
+          </select>
+          <span className="text-xs text-slate-500">{filtered.length} entries</span>
+        </div>
+      </div>
+
+      <div className="section-card">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Timestamp</th>
+              <th>Actor</th>
+              <th>Action</th>
+              <th>Entity</th>
+              <th>Details</th>
+              <th>IP</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((entry) => (
+              <tr key={entry.id}>
+                <td>{formatDate(entry.createdAt)}</td>
+                <td>{entry.actor}</td>
+                <td className="font-medium text-white">{entry.action}</td>
+                <td>{entry.entity}</td>
+                <td>{entry.metadata}</td>
+                <td>{entry.ip}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/app/(dashboard)/events/page.tsx
+++ b/apps/admin/app/(dashboard)/events/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import type { ControlRoomEvent } from '@/lib/data';
+import { events } from '@/lib/data';
+import { formatDate } from '@/lib/format';
+
+function severityStyle(severity: ControlRoomEvent['severity']) {
+  switch (severity) {
+    case 'critical':
+      return 'badge-danger';
+    case 'warning':
+      return 'badge-warning';
+    default:
+      return 'badge-success';
+  }
+}
+
+function severityLabel(severity: ControlRoomEvent['severity']) {
+  return severity.toUpperCase();
+}
+
+export default function EventsPage() {
+  const [query, setQuery] = useState('');
+  const [severity, setSeverity] = useState<'all' | ControlRoomEvent['severity']>('all');
+
+  const filtered = useMemo(() => {
+    return events.filter((event) => {
+      const matchesQuery = `${event.message} ${event.source} ${event.type}`
+        .toLowerCase()
+        .includes(query.toLowerCase());
+      const matchesSeverity = severity === 'all' || event.severity === severity;
+      return matchesQuery && matchesSeverity;
+    });
+  }, [query, severity]);
+
+  return (
+    <div className="section-card space-y-6">
+      <div className="filter-bar">
+        <input
+          type="search"
+          placeholder="Search events"
+          className="search-input"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+        <div className="tab-bar w-full sm:w-auto">
+          {['all', 'info', 'warning', 'critical'].map((value) => (
+            <button
+              key={value}
+              type="button"
+              className={`tab-button ${severity === value ? 'active' : ''}`}
+              onClick={() => setSeverity(value as typeof severity)}
+            >
+              {value === 'all' ? 'All severities' : severityLabel(value as ControlRoomEvent['severity'])}
+            </button>
+          ))}
+        </div>
+        <span className="text-xs text-slate-500">{filtered.length} events</span>
+      </div>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Timestamp</th>
+            <th>Type</th>
+            <th>Message</th>
+            <th>Source</th>
+            <th>Severity</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((event) => (
+            <tr key={event.id}>
+              <td>{formatDate(event.createdAt)}</td>
+              <td className="font-medium text-white">{event.type}</td>
+              <td>{event.message}</td>
+              <td>{event.source}</td>
+              <td>
+                <span className={`badge ${severityStyle(event.severity)}`}>{severityLabel(event.severity)}</span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/admin/app/(dashboard)/layout.tsx
+++ b/apps/admin/app/(dashboard)/layout.tsx
@@ -1,0 +1,31 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { ReactNode } from 'react';
+
+import { Sidebar } from '@/components/Sidebar';
+import { TopBar } from '@/components/TopBar';
+import { SESSION_COOKIE_NAME, verifySessionToken } from '@/lib/auth';
+
+export default function DashboardLayout({
+  children
+}: {
+  children: ReactNode;
+}) {
+  const cookieStore = cookies();
+  const token = cookieStore.get(SESSION_COOKIE_NAME)?.value;
+  const session = verifySessionToken(token);
+
+  if (!session) {
+    redirect('/login');
+  }
+
+  return (
+    <div className="main-container">
+      <Sidebar />
+      <main className="content">
+        <TopBar username={session.username} />
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/apps/admin/app/(dashboard)/orders/page.tsx
+++ b/apps/admin/app/(dashboard)/orders/page.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import type { HedgeOrder } from '@/lib/data';
+import { hedgeOrders } from '@/lib/data';
+import { formatDate } from '@/lib/format';
+
+const desks = ['All desks', ...new Set(hedgeOrders.map((order) => order.desk))];
+const statuses: Array<'All statuses' | HedgeOrder['status']> = ['All statuses', 'Working', 'Partial', 'Hedged', 'Rejected'];
+
+function statusStyle(status: HedgeOrder['status']) {
+  switch (status) {
+    case 'Hedged':
+      return 'badge-success';
+    case 'Rejected':
+      return 'badge-danger';
+    default:
+      return 'badge-warning';
+  }
+}
+
+export default function OrdersPage() {
+  const [query, setQuery] = useState('');
+  const [desk, setDesk] = useState<string>('All desks');
+  const [status, setStatus] = useState<'All statuses' | HedgeOrder['status']>('All statuses');
+
+  const filtered = useMemo(() => {
+    return hedgeOrders.filter((order) => {
+      const matchesQuery = `${order.id} ${order.symbol}`.toLowerCase().includes(query.toLowerCase());
+      const matchesDesk = desk === 'All desks' || order.desk === desk;
+      const matchesStatus = status === 'All statuses' || order.status === status;
+      return matchesQuery && matchesDesk && matchesStatus;
+    });
+  }, [query, desk, status]);
+
+  return (
+    <div className="space-y-6">
+      <div className="section-card space-y-4">
+        <div className="filter-bar">
+          <input
+            type="search"
+            placeholder="Search hedge orders"
+            className="search-input"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+          <select className="filter-pill" value={desk} onChange={(event) => setDesk(event.target.value)}>
+            {desks.map((value) => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
+          </select>
+          <select
+            className="filter-pill"
+            value={status}
+            onChange={(event) => setStatus(event.target.value as typeof status)}
+          >
+            {statuses.map((value) => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
+          </select>
+          <span className="text-xs text-slate-500">{filtered.length} orders</span>
+        </div>
+      </div>
+
+      <div className="section-card">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Order</th>
+              <th>Strategy</th>
+              <th>Desk</th>
+              <th>Quantity</th>
+              <th>Filled</th>
+              <th>Placed</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((order) => (
+              <tr key={order.id}>
+                <td className="text-sm font-semibold text-white">{order.id}</td>
+                <td>{order.strategy}</td>
+                <td>{order.desk}</td>
+                <td>{order.quantity.toLocaleString()}</td>
+                <td>{order.filled.toLocaleString()}</td>
+                <td>{formatDate(order.placedAt)}</td>
+                <td>
+                  <span className={`badge ${statusStyle(order.status)}`}>{order.status}</span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/app/(dashboard)/page.tsx
+++ b/apps/admin/app/(dashboard)/page.tsx
@@ -1,0 +1,185 @@
+import Link from 'next/link';
+
+import { RealtimeCounters } from '@/components/RealtimeCounters';
+import { auditLog, events, hedgeOrders, payments, quotes } from '@/lib/data';
+import { formatAmount, formatDate, formatNotional } from '@/lib/format';
+
+export default function OverviewPage() {
+  return (
+    <div className="space-y-10">
+      <section>
+        <RealtimeCounters />
+      </section>
+
+      <section className="section-card">
+        <div className="section-title">
+          <span>Latest Events</span>
+          <Link href="/events" className="button-secondary text-xs px-3 py-1.5">
+            View all
+          </Link>
+        </div>
+        <div className="space-y-4">
+          {events.slice(0, 4).map((event) => (
+            <div key={event.id} className="flex items-start justify-between gap-3 rounded-xl border border-slate-800/70 bg-slate-900/70 px-4 py-3">
+              <div>
+                <div className="flex items-center gap-2 text-sm text-slate-300">
+                  <span className="font-semibold text-white">{event.type}</span>
+                  <span className="text-xs text-slate-500">{formatDate(event.createdAt)}</span>
+                </div>
+                <p className="text-sm text-slate-200">{event.message}</p>
+                <p className="text-xs text-slate-500">Source: {event.source}</p>
+              </div>
+              <span
+                className={`badge ${
+                  event.severity === 'critical'
+                    ? 'badge-danger'
+                    : event.severity === 'warning'
+                      ? 'badge-warning'
+                      : 'badge-success'
+                }`}
+              >
+                {event.severity.toUpperCase()}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        <div className="section-card">
+          <div className="section-title">Outstanding Quotes</div>
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Quote</th>
+                <th>Trader</th>
+                <th>Notional</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {quotes.slice(0, 4).map((quote) => (
+                <tr key={quote.id}>
+                  <td className="text-sm font-semibold text-white">
+                    {quote.id}
+                    <div className="text-xs text-slate-400">{quote.pair} @ {quote.price.toFixed(4)}</div>
+                  </td>
+                  <td>{quote.trader}</td>
+                  <td>{formatNotional(quote.notional)}</td>
+                  <td>
+                    <span
+                      className={`badge ${
+                        quote.status === 'Open'
+                          ? 'badge-success'
+                          : quote.status === 'Filled'
+                            ? 'badge-warning'
+                            : 'badge-danger'
+                      }`}
+                    >
+                      {quote.status}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div className="section-card">
+          <div className="section-title">Payment Exceptions</div>
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Payment</th>
+                <th>Counterparty</th>
+                <th>Amount</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {payments
+                .filter((payment) => payment.status !== 'Settled')
+                .slice(0, 4)
+                .map((payment) => (
+                  <tr key={payment.id}>
+                    <td className="text-sm font-semibold text-white">{payment.id}</td>
+                    <td>{payment.counterparty}</td>
+                    <td>{formatAmount(payment.amount, payment.currency)}</td>
+                    <td>
+                      <span
+                        className={`badge ${
+                          payment.status === 'Pending'
+                            ? 'badge-warning'
+                            : payment.status === 'Failed'
+                              ? 'badge-danger'
+                              : 'badge-success'
+                        }`}
+                      >
+                        {payment.status}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="section-card">
+        <div className="section-title">Hedge Orders</div>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Order</th>
+              <th>Desk</th>
+              <th>Progress</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {hedgeOrders.slice(0, 4).map((order) => (
+              <tr key={order.id}>
+                <td className="text-sm font-semibold text-white">
+                  {order.id}
+                  <div className="text-xs text-slate-400">{order.symbol}</div>
+                </td>
+                <td>{order.desk}</td>
+                <td>
+                  <div className="text-sm text-slate-200">
+                    {order.filled.toLocaleString()} / {order.quantity.toLocaleString()}
+                  </div>
+                </td>
+                <td>
+                  <span
+                    className={`badge ${
+                      order.status === 'Hedged'
+                        ? 'badge-success'
+                        : order.status === 'Rejected'
+                          ? 'badge-danger'
+                          : 'badge-warning'
+                    }`}
+                  >
+                    {order.status}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section className="section-card">
+        <div className="section-title">Audit Trail Snapshots</div>
+        <div className="grid gap-4 md:grid-cols-2">
+          {auditLog.slice(0, 4).map((entry) => (
+            <div key={entry.id} className="rounded-xl border border-slate-800/70 bg-slate-900/60 p-4">
+              <div className="text-sm font-semibold text-white">{entry.action}</div>
+              <div className="text-xs text-slate-400">{formatDate(entry.createdAt)} • {entry.actor}</div>
+              <p className="mt-2 text-sm text-slate-200">{entry.metadata}</p>
+              <div className="mt-1 text-xs text-slate-500">Entity {entry.entity} • {entry.ip}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/admin/app/(dashboard)/payments/page.tsx
+++ b/apps/admin/app/(dashboard)/payments/page.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import type { Payment } from '@/lib/data';
+import { payments } from '@/lib/data';
+import { formatAmount, formatDate } from '@/lib/format';
+
+const regions = ['All regions', 'US', 'EU', 'APAC', 'UK'];
+const statuses: Array<'All statuses' | Payment['status']> = ['All statuses', 'Pending', 'Settled', 'Failed'];
+
+function statusStyle(status: Payment['status']) {
+  switch (status) {
+    case 'Settled':
+      return 'badge-success';
+    case 'Pending':
+      return 'badge-warning';
+    default:
+      return 'badge-danger';
+  }
+}
+
+export default function PaymentsPage() {
+  const [query, setQuery] = useState('');
+  const [region, setRegion] = useState<string>('All regions');
+  const [status, setStatus] = useState<'All statuses' | Payment['status']>('All statuses');
+
+  const filtered = useMemo(() => {
+    return payments.filter((payment) => {
+      const matchesQuery = `${payment.counterparty} ${payment.id}`
+        .toLowerCase()
+        .includes(query.toLowerCase());
+      const matchesRegion = region === 'All regions' || payment.region === region;
+      const matchesStatus = status === 'All statuses' || payment.status === status;
+      return matchesQuery && matchesRegion && matchesStatus;
+    });
+  }, [query, region, status]);
+
+  const totalPending = useMemo(() => {
+    return filtered
+      .filter((payment) => payment.status === 'Pending')
+      .reduce((sum, payment) => sum + payment.amount, 0);
+  }, [filtered]);
+
+  return (
+    <div className="space-y-6">
+      <div className="section-card space-y-4">
+        <div className="filter-bar">
+          <input
+            type="search"
+            placeholder="Search payments"
+            className="search-input"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+          <select
+            className="filter-pill"
+            value={region}
+            onChange={(event) => setRegion(event.target.value)}
+          >
+            {regions.map((value) => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
+          </select>
+          <select
+            className="filter-pill"
+            value={status}
+            onChange={(event) => setStatus(event.target.value as typeof status)}
+          >
+            {statuses.map((value) => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
+          </select>
+          <span className="text-xs text-slate-500">{filtered.length} records</span>
+        </div>
+        <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+          <div className="text-xs uppercase tracking-wide text-slate-400">Pending volume</div>
+          <div className="mt-1 text-2xl font-bold text-white">{formatAmount(totalPending, 'USD')}</div>
+          <div className="timer">Calculated on filtered dataset</div>
+        </div>
+      </div>
+
+      <div className="section-card">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Payment</th>
+              <th>Counterparty</th>
+              <th>Amount</th>
+              <th>Method</th>
+              <th>Region</th>
+              <th>Last update</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((payment) => (
+              <tr key={payment.id}>
+                <td className="text-sm font-semibold text-white">{payment.id}</td>
+                <td>{payment.counterparty}</td>
+                <td>{formatAmount(payment.amount, payment.currency)}</td>
+                <td>{payment.method}</td>
+                <td>{payment.region}</td>
+                <td>{formatDate(payment.updatedAt)}</td>
+                <td>
+                  <span className={`badge ${statusStyle(payment.status)}`}>{payment.status}</span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/app/(dashboard)/quotes/page.tsx
+++ b/apps/admin/app/(dashboard)/quotes/page.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import type { Quote } from '@/lib/data';
+import { quotes } from '@/lib/data';
+import { formatNotional, formatRelativeTime } from '@/lib/format';
+
+function statusStyle(status: Quote['status']) {
+  switch (status) {
+    case 'Open':
+      return 'badge-success';
+    case 'Filled':
+      return 'badge-warning';
+    default:
+      return 'badge-danger';
+  }
+}
+
+export default function QuotesPage() {
+  const [query, setQuery] = useState('');
+  const [status, setStatus] = useState<'all' | Quote['status']>('all');
+  const [clock, setClock] = useState(Date.now());
+
+  useEffect(() => {
+    const interval = setInterval(() => setClock(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const filtered = useMemo(() => {
+    return quotes.filter((quote) => {
+      const matchesQuery = `${quote.id} ${quote.pair} ${quote.trader}`
+        .toLowerCase()
+        .includes(query.toLowerCase());
+      const matchesStatus = status === 'all' || quote.status === status;
+      return matchesQuery && matchesStatus;
+    });
+  }, [query, status]);
+
+  const soonestExpiry = useMemo(() => {
+    const openQuotes = filtered.filter((quote) => quote.status === 'Open');
+    if (openQuotes.length === 0) return null;
+    return openQuotes.reduce((soonest, quote) => {
+      return new Date(quote.expiry) < new Date(soonest.expiry) ? quote : soonest;
+    });
+  }, [filtered, clock]);
+
+  return (
+    <div className="space-y-6">
+      <div className="section-card space-y-4">
+        <div className="filter-bar">
+          <input
+            type="search"
+            placeholder="Search quotes"
+            className="search-input"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+          <div className="tab-bar w-full sm:w-auto">
+            {['all', 'Open', 'Filled', 'Expired'].map((value) => (
+              <button
+                key={value}
+                type="button"
+                className={`tab-button ${status === value ? 'active' : ''}`}
+                onClick={() => setStatus(value as typeof status)}
+              >
+                {value === 'all' ? 'All statuses' : value}
+              </button>
+            ))}
+          </div>
+          <span className="text-xs text-slate-500">{filtered.length} quotes</span>
+        </div>
+        {soonestExpiry ? (
+          <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+            <div className="text-xs uppercase tracking-wide text-slate-400">Next expiry</div>
+            <div className="mt-1 flex items-center justify-between">
+              <div>
+                <div className="text-sm font-semibold text-white">{soonestExpiry.id}</div>
+                <div className="text-xs text-slate-400">{soonestExpiry.pair} • {soonestExpiry.trader}</div>
+              </div>
+              <div className="text-right">
+                <div className="text-lg font-bold text-white">{formatRelativeTime(soonestExpiry.expiry)}</div>
+                <div className="timer">Expires at {new Date(soonestExpiry.expiry).toLocaleTimeString()}</div>
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="section-card">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Quote</th>
+              <th>Trader</th>
+              <th>Notional</th>
+              <th>Price</th>
+              <th>Expires</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((quote) => (
+              <tr key={quote.id}>
+                <td className="text-sm font-semibold text-white">{quote.id}</td>
+                <td>{quote.trader}</td>
+                <td>{formatNotional(quote.notional)}</td>
+                <td>{quote.price.toFixed(4)}</td>
+                <td>
+                  <span className="text-sm text-slate-200">{formatRelativeTime(quote.expiry)}</span>
+                  <div className="timer">{new Date(quote.expiry).toLocaleTimeString()}</div>
+                </td>
+                <td>
+                  <span className={`badge ${statusStyle(quote.status)}`}>{quote.status}</span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/app/api/login/route.ts
+++ b/apps/admin/app/api/login/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+
+import { createSessionToken, sessionCookieOptions } from '@/lib/auth';
+
+const ADMIN_USER = process.env.ADMIN_USER ?? 'operator';
+const ADMIN_PASS = process.env.ADMIN_PASS ?? 'trader!123';
+
+export async function POST(request: Request) {
+  const { username, password } = await request.json();
+
+  if (typeof username !== 'string' || typeof password !== 'string') {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  if (username !== ADMIN_USER || password !== ADMIN_PASS) {
+    return NextResponse.json({ error: 'Incorrect credentials' }, { status: 401 });
+  }
+
+  const token = createSessionToken(username);
+  const cookie = sessionCookieOptions();
+
+  const response = NextResponse.json({ success: true });
+  response.cookies.set({
+    name: cookie.name,
+    value: token,
+    httpOnly: cookie.httpOnly,
+    sameSite: cookie.sameSite,
+    secure: cookie.secure,
+    path: cookie.path,
+    maxAge: cookie.maxAge
+  });
+
+  return response;
+}

--- a/apps/admin/app/api/logout/route.ts
+++ b/apps/admin/app/api/logout/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+
+import { sessionCookieOptions } from '@/lib/auth';
+
+export async function POST() {
+  const cookie = sessionCookieOptions();
+  const response = NextResponse.json({ success: true });
+  response.cookies.set({
+    name: cookie.name,
+    value: '',
+    httpOnly: cookie.httpOnly,
+    sameSite: cookie.sameSite,
+    secure: cookie.secure,
+    path: cookie.path,
+    maxAge: 0
+  });
+  return response;
+}

--- a/apps/admin/app/api/stream/route.ts
+++ b/apps/admin/app/api/stream/route.ts
@@ -1,0 +1,51 @@
+import { auditLog, hedgeOrders, payments, quotes } from '@/lib/data';
+
+function formatTime() {
+  return new Date().toLocaleTimeString('en-US', {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  });
+}
+
+function randomize(base: number, variance: number) {
+  const delta = Math.round((Math.random() - 0.5) * variance);
+  return Math.max(0, base + delta);
+}
+
+export function GET() {
+  const encoder = new TextEncoder();
+  let interval: ReturnType<typeof setInterval> | undefined;
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const sendEvent = () => {
+        const payload = {
+          quotesActive: randomize(quotes.filter((quote) => quote.status === 'Open').length, 2),
+          paymentsPending: randomize(payments.filter((payment) => payment.status === 'Pending').length, 1),
+          hedgesOpen: randomize(hedgeOrders.filter((order) => order.status !== 'Hedged').length, 1),
+          auditsToday: randomize(auditLog.length, 2),
+          lastUpdated: formatTime()
+        };
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(payload)}\n\n`));
+      };
+
+      sendEvent();
+      interval = setInterval(sendEvent, 5000);
+    },
+    cancel() {
+      if (interval) {
+        clearInterval(interval);
+      }
+    }
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive'
+    }
+  });
+}

--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -1,0 +1,133 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 248 250 252;
+  --foreground: 15 23 42;
+  --muted: 100 116 139;
+  --accent: 59 130 246;
+}
+
+body {
+  color: rgb(var(--foreground));
+  background-color: rgb(var(--background));
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  min-height: 100vh;
+}
+
+.main-container {
+  @apply flex min-h-screen bg-slate-900 text-slate-100;
+}
+
+.sidebar {
+  @apply w-64 bg-slate-950 border-r border-slate-800 px-6 py-8 flex flex-col gap-6;
+}
+
+.sidebar a {
+  @apply text-slate-300 hover:text-white transition-colors font-medium;
+}
+
+.sidebar a.active {
+  @apply text-white bg-slate-800/70 px-3 py-2 rounded-lg;
+}
+
+.content {
+  @apply flex-1 p-8 space-y-8;
+}
+
+.section-card {
+  @apply rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-xl shadow-slate-950/40;
+}
+
+.section-title {
+  @apply text-lg font-semibold text-slate-100 mb-4 flex items-center gap-3;
+}
+
+.stat-grid {
+  @apply grid gap-4 sm:grid-cols-2 xl:grid-cols-4;
+}
+
+.stat-card {
+  @apply section-card flex flex-col gap-2;
+}
+
+.stat-value {
+  @apply text-3xl font-bold text-white;
+}
+
+.table {
+  @apply w-full border-collapse;
+}
+
+.table thead tr {
+  @apply text-left text-xs uppercase tracking-wide text-slate-400;
+}
+
+.table thead th {
+  @apply border-b border-slate-800 pb-3;
+}
+
+.table tbody tr {
+  @apply border-b border-slate-800/60 hover:bg-slate-800/40 transition-colors;
+}
+
+.table tbody td {
+  @apply py-3 text-sm text-slate-200;
+}
+
+.badge {
+  @apply inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-semibold;
+}
+
+.badge-success {
+  @apply badge bg-emerald-500/20 text-emerald-300;
+}
+
+.badge-warning {
+  @apply badge bg-amber-500/20 text-amber-300;
+}
+
+.badge-danger {
+  @apply badge bg-rose-500/20 text-rose-300;
+}
+
+.input {
+  @apply w-full rounded-xl border border-slate-700 bg-slate-900/80 px-4 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500/70;
+}
+
+.button-primary {
+  @apply inline-flex items-center justify-center rounded-xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-blue-600/20 transition hover:bg-blue-500;
+}
+
+.button-secondary {
+  @apply inline-flex items-center justify-center rounded-xl border border-slate-700 bg-slate-900/50 px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-slate-800;
+}
+
+.tab-bar {
+  @apply flex items-center gap-2 rounded-xl bg-slate-900/70 p-1 border border-slate-800;
+}
+
+.tab-button {
+  @apply flex-1 rounded-lg px-3 py-2 text-sm font-medium text-slate-300 hover:text-white;
+}
+
+.tab-button.active {
+  @apply bg-blue-600 text-white shadow-lg shadow-blue-600/20;
+}
+
+.filter-bar {
+  @apply flex flex-wrap items-center gap-3;
+}
+
+.filter-pill {
+  @apply inline-flex items-center gap-2 rounded-full border border-slate-700 bg-slate-900/70 px-3 py-1.5 text-xs font-medium text-slate-200;
+}
+
+.search-input {
+  @apply input sm:w-64;
+}
+
+.timer {
+  @apply text-xs font-medium text-slate-400;
+}

--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'FX Option Control Room',
+  description: 'Internal operator dashboard for quotes, payments, hedges and audit trails.'
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/admin/components/LoginForm.tsx
+++ b/apps/admin/components/LoginForm.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+
+export function LoginForm() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ username, password })
+      });
+      if (!response.ok) {
+        const payload = await response.json();
+        setError(payload.error ?? 'Unable to sign in');
+        return;
+      }
+      window.location.href = '/';
+    } catch (err) {
+      setError('Network error. Please retry.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5 rounded-2xl border border-slate-800 bg-slate-900/70 p-8 shadow-2xl shadow-slate-900/60">
+      <div>
+        <h1 className="text-2xl font-semibold text-white">FX Option Control Room</h1>
+        <p className="text-sm text-slate-400">Operator access requires secure credentials.</p>
+      </div>
+      <div className="space-y-1.5">
+        <label htmlFor="username" className="text-sm font-medium text-slate-200">
+          Username
+        </label>
+        <input
+          id="username"
+          name="username"
+          type="text"
+          autoComplete="username"
+          className="input"
+          value={username}
+          onChange={(event) => setUsername(event.target.value)}
+          required
+        />
+      </div>
+      <div className="space-y-1.5">
+        <label htmlFor="password" className="text-sm font-medium text-slate-200">
+          Password
+        </label>
+        <input
+          id="password"
+          name="password"
+          type="password"
+          autoComplete="current-password"
+          className="input"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          required
+        />
+      </div>
+      {error ? <div className="text-sm text-rose-300">{error}</div> : null}
+      <button type="submit" className="button-primary w-full" disabled={loading}>
+        {loading ? 'Validating…' : 'Sign in'}
+      </button>
+      <p className="text-xs text-slate-500">
+        Access is limited to authorised trading operations staff. Credentials rotate every 90 days.
+      </p>
+    </form>
+  );
+}

--- a/apps/admin/components/RealtimeCounters.tsx
+++ b/apps/admin/components/RealtimeCounters.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+type Metrics = {
+  quotesActive: number;
+  paymentsPending: number;
+  hedgesOpen: number;
+  auditsToday: number;
+  lastUpdated: string;
+};
+
+const initialState: Metrics = {
+  quotesActive: 0,
+  paymentsPending: 0,
+  hedgesOpen: 0,
+  auditsToday: 0,
+  lastUpdated: '—'
+};
+
+export function RealtimeCounters() {
+  const [metrics, setMetrics] = useState<Metrics>(initialState);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const source = new EventSource('/api/stream');
+    source.onmessage = (event) => {
+      try {
+        const payload = JSON.parse(event.data) as Metrics;
+        setMetrics(payload);
+      } catch (error) {
+        console.error('Failed to parse metrics payload', error);
+      }
+    };
+    source.onerror = () => {
+      if (!timeoutRef.current) {
+        timeoutRef.current = setTimeout(() => {
+          setMetrics(initialState);
+          timeoutRef.current = null;
+        }, 5000);
+      }
+    };
+    return () => {
+      source.close();
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <div className="stat-grid">
+      <div className="stat-card">
+        <div className="text-sm uppercase tracking-wide text-slate-400">Active Quotes</div>
+        <div className="stat-value">{metrics.quotesActive}</div>
+        <div className="timer">Updated {metrics.lastUpdated}</div>
+      </div>
+      <div className="stat-card">
+        <div className="text-sm uppercase tracking-wide text-slate-400">Pending Payments</div>
+        <div className="stat-value">{metrics.paymentsPending}</div>
+        <div className="timer">Updated {metrics.lastUpdated}</div>
+      </div>
+      <div className="stat-card">
+        <div className="text-sm uppercase tracking-wide text-slate-400">Open Hedges</div>
+        <div className="stat-value">{metrics.hedgesOpen}</div>
+        <div className="timer">Updated {metrics.lastUpdated}</div>
+      </div>
+      <div className="stat-card">
+        <div className="text-sm uppercase tracking-wide text-slate-400">Audit Events Today</div>
+        <div className="stat-value">{metrics.auditsToday}</div>
+        <div className="timer">Updated {metrics.lastUpdated}</div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/components/Sidebar.tsx
+++ b/apps/admin/components/Sidebar.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const routes = [
+  { href: '/', label: 'Overview', icon: '📊' },
+  { href: '/events', label: 'Events', icon: '🛰️' },
+  { href: '/quotes', label: 'Quotes', icon: '💱' },
+  { href: '/payments', label: 'Payments', icon: '💸' },
+  { href: '/orders', label: 'Orders & Fills', icon: '📈' },
+  { href: '/audit', label: 'Audit', icon: '🧾' }
+];
+
+export function Sidebar() {
+  const pathname = usePathname() ?? '/';
+
+  return (
+    <aside className="sidebar">
+      <div>
+        <div className="text-xs uppercase tracking-wide text-slate-500">Control Room</div>
+        <div className="mt-2 text-lg font-semibold text-white">FX Option</div>
+      </div>
+      <nav className="flex flex-col gap-2">
+        {routes.map((route) => {
+          const isActive = pathname === route.href;
+          return (
+            <Link
+              key={route.href}
+              href={route.href}
+              className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition ${
+                isActive
+                  ? 'bg-slate-800/70 font-semibold text-white'
+                  : 'font-medium text-slate-300 hover:text-white'
+              }`}
+            >
+              <span className="text-lg">{route.icon}</span>
+              <span>{route.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+      <div className="mt-auto text-xs text-slate-500">
+        Secure operator access • {new Date().getFullYear()}
+      </div>
+    </aside>
+  );
+}

--- a/apps/admin/components/TopBar.tsx
+++ b/apps/admin/components/TopBar.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState } from 'react';
+
+export function TopBar({ username }: { username: string }) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleLogout = async () => {
+    setIsSubmitting(true);
+    try {
+      await fetch('/api/logout', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+      window.location.href = '/login';
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <header className="flex flex-wrap items-center justify-between gap-4">
+      <div>
+        <h1 className="text-2xl font-semibold text-white">Control Room</h1>
+        <p className="text-sm text-slate-400">Operational oversight of pricing, settlement and risk hedging flows.</p>
+      </div>
+      <div className="flex items-center gap-3">
+        <div className="rounded-xl border border-slate-700 bg-slate-900/70 px-4 py-2 text-sm text-slate-300">
+          Signed in as <span className="font-semibold text-white">{username}</span>
+        </div>
+        <button
+          type="button"
+          className="button-secondary"
+          onClick={handleLogout}
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'Signing out…' : 'Sign out'}
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/apps/admin/lib/auth.ts
+++ b/apps/admin/lib/auth.ts
@@ -1,0 +1,69 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+
+const SESSION_COOKIE = 'admin_session';
+const SESSION_DURATION_MS = 1000 * 60 * 60 * 8; // 8 hours
+const ALGORITHM = 'sha256';
+
+const secret = process.env.ADMIN_SECRET ?? 'change-me-in-production';
+
+interface SessionPayload {
+  username: string;
+  exp: number;
+}
+
+function base64UrlEncode(value: string) {
+  return Buffer.from(value).toString('base64url');
+}
+
+function base64UrlDecode(value: string) {
+  return Buffer.from(value, 'base64url').toString();
+}
+
+function sign(payload: string) {
+  return createHmac(ALGORITHM, secret).update(payload).digest('base64url');
+}
+
+export function createSessionToken(username: string) {
+  const payload: SessionPayload = {
+    username,
+    exp: Date.now() + SESSION_DURATION_MS
+  };
+  const body = base64UrlEncode(JSON.stringify(payload));
+  const signature = sign(body);
+  return `${body}.${signature}`;
+}
+
+export function verifySessionToken(token: string | undefined): SessionPayload | null {
+  if (!token) return null;
+  const [body, signature] = token.split('.');
+  if (!body || !signature) {
+    return null;
+  }
+  const expected = sign(body);
+  const valid = timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
+  if (!valid) {
+    return null;
+  }
+  try {
+    const payload = JSON.parse(base64UrlDecode(body)) as SessionPayload;
+    if (payload.exp < Date.now()) {
+      return null;
+    }
+    return payload;
+  } catch (error) {
+    return null;
+  }
+}
+
+export function sessionCookieOptions() {
+  return {
+    name: SESSION_COOKIE,
+    httpOnly: true as const,
+    sameSite: 'lax' as const,
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: SESSION_DURATION_MS / 1000
+  };
+}
+
+export const SESSION_COOKIE_NAME = SESSION_COOKIE;

--- a/apps/admin/lib/data.ts
+++ b/apps/admin/lib/data.ts
@@ -1,0 +1,285 @@
+export type EventSeverity = 'info' | 'warning' | 'critical';
+
+export interface ControlRoomEvent {
+  id: string;
+  createdAt: string;
+  type: string;
+  message: string;
+  severity: EventSeverity;
+  source: string;
+}
+
+export interface Quote {
+  id: string;
+  pair: string;
+  side: 'Buy' | 'Sell';
+  trader: string;
+  notional: number;
+  price: number;
+  status: 'Open' | 'Filled' | 'Expired';
+  expiry: string;
+}
+
+export interface Payment {
+  id: string;
+  counterparty: string;
+  currency: string;
+  amount: number;
+  method: 'Wire' | 'Swift' | 'ACH' | 'SEPA';
+  status: 'Pending' | 'Settled' | 'Failed';
+  updatedAt: string;
+  region: string;
+}
+
+export interface HedgeOrder {
+  id: string;
+  symbol: string;
+  strategy: 'Spot' | 'Forward' | 'Option';
+  side: 'Buy' | 'Sell';
+  quantity: number;
+  filled: number;
+  status: 'Working' | 'Hedged' | 'Partial' | 'Rejected';
+  desk: string;
+  placedAt: string;
+}
+
+export interface AuditLogEntry {
+  id: string;
+  actor: string;
+  action: string;
+  entity: string;
+  metadata: string;
+  createdAt: string;
+  ip: string;
+}
+
+export const events: ControlRoomEvent[] = [
+  {
+    id: 'evt-9012',
+    createdAt: '2024-05-12T08:25:00Z',
+    type: 'RFQ',
+    message: 'Incoming RFQ for 50M EUR/USD from Lumi Capital',
+    severity: 'info',
+    source: 'RFQ Engine'
+  },
+  {
+    id: 'evt-9013',
+    createdAt: '2024-05-12T08:32:00Z',
+    type: 'Payment',
+    message: 'US Treasury wire delayed: reference PMT-441',
+    severity: 'warning',
+    source: 'Payments Orchestrator'
+  },
+  {
+    id: 'evt-9014',
+    createdAt: '2024-05-12T08:35:00Z',
+    type: 'Hedge',
+    message: 'Forward hedge auto-booked for quote QT-2209',
+    severity: 'info',
+    source: 'Hedge Engine'
+  },
+  {
+    id: 'evt-9015',
+    createdAt: '2024-05-12T08:41:00Z',
+    type: 'Alert',
+    message: 'Rejected fill for order OR-882 (insufficient credit)',
+    severity: 'critical',
+    source: 'Prime Broker API'
+  },
+  {
+    id: 'evt-9016',
+    createdAt: '2024-05-12T08:53:00Z',
+    type: 'Audit',
+    message: 'Admin role granted to cfo@clientbank.com',
+    severity: 'warning',
+    source: 'Access Control'
+  }
+];
+
+const now = new Date();
+
+function minutesFromNow(minutes: number) {
+  return new Date(now.getTime() + minutes * 60 * 1000).toISOString();
+}
+
+export const quotes: Quote[] = [
+  {
+    id: 'QT-2207',
+    pair: 'EUR/USD',
+    side: 'Sell',
+    trader: 'Morgan Hart',
+    notional: 25000000,
+    price: 1.0834,
+    status: 'Open',
+    expiry: minutesFromNow(4)
+  },
+  {
+    id: 'QT-2208',
+    pair: 'GBP/USD',
+    side: 'Buy',
+    trader: 'Priya Singh',
+    notional: 10000000,
+    price: 1.2651,
+    status: 'Filled',
+    expiry: minutesFromNow(-2)
+  },
+  {
+    id: 'QT-2209',
+    pair: 'USD/JPY',
+    side: 'Sell',
+    trader: 'Noah Park',
+    notional: 15000000,
+    price: 155.42,
+    status: 'Open',
+    expiry: minutesFromNow(9)
+  },
+  {
+    id: 'QT-2210',
+    pair: 'EUR/GBP',
+    side: 'Buy',
+    trader: 'Chloe Martin',
+    notional: 8000000,
+    price: 0.8571,
+    status: 'Expired',
+    expiry: minutesFromNow(-18)
+  },
+  {
+    id: 'QT-2211',
+    pair: 'AUD/USD',
+    side: 'Buy',
+    trader: 'Lucas Chen',
+    notional: 5000000,
+    price: 0.6614,
+    status: 'Open',
+    expiry: minutesFromNow(14)
+  }
+];
+
+export const payments: Payment[] = [
+  {
+    id: 'PMT-441',
+    counterparty: 'Northwind Energy',
+    currency: 'USD',
+    amount: 12600000,
+    method: 'Wire',
+    status: 'Pending',
+    updatedAt: '2024-05-12T07:58:00Z',
+    region: 'US'
+  },
+  {
+    id: 'PMT-442',
+    counterparty: 'Aurora Partners',
+    currency: 'EUR',
+    amount: 6200000,
+    method: 'SEPA',
+    status: 'Settled',
+    updatedAt: '2024-05-12T07:15:00Z',
+    region: 'EU'
+  },
+  {
+    id: 'PMT-443',
+    counterparty: 'Harbor Holdings',
+    currency: 'JPY',
+    amount: 1850000000,
+    method: 'Swift',
+    status: 'Pending',
+    updatedAt: '2024-05-12T08:05:00Z',
+    region: 'APAC'
+  },
+  {
+    id: 'PMT-444',
+    counterparty: 'Zenith Commodities',
+    currency: 'GBP',
+    amount: 4200000,
+    method: 'Wire',
+    status: 'Failed',
+    updatedAt: '2024-05-12T06:49:00Z',
+    region: 'UK'
+  }
+];
+
+export const hedgeOrders: HedgeOrder[] = [
+  {
+    id: 'OR-880',
+    symbol: 'EURUSD 1M',
+    strategy: 'Forward',
+    side: 'Sell',
+    quantity: 25000000,
+    filled: 25000000,
+    status: 'Hedged',
+    desk: 'London',
+    placedAt: '2024-05-12T07:22:00Z'
+  },
+  {
+    id: 'OR-881',
+    symbol: 'USDJPY Spot',
+    strategy: 'Spot',
+    side: 'Buy',
+    quantity: 15000000,
+    filled: 12000000,
+    status: 'Partial',
+    desk: 'Singapore',
+    placedAt: '2024-05-12T07:59:00Z'
+  },
+  {
+    id: 'OR-882',
+    symbol: 'GBPUSD 3M',
+    strategy: 'Forward',
+    side: 'Sell',
+    quantity: 12000000,
+    filled: 0,
+    status: 'Rejected',
+    desk: 'New York',
+    placedAt: '2024-05-12T08:38:00Z'
+  },
+  {
+    id: 'OR-883',
+    symbol: 'AUDUSD 2W',
+    strategy: 'Option',
+    side: 'Buy',
+    quantity: 5000000,
+    filled: 2000000,
+    status: 'Working',
+    desk: 'Sydney',
+    placedAt: '2024-05-12T08:47:00Z'
+  }
+];
+
+export const auditLog: AuditLogEntry[] = [
+  {
+    id: 'AUD-9931',
+    actor: 'sara@fxoption.com',
+    action: 'Updated settlement instructions',
+    entity: 'PMT-441',
+    metadata: 'Changed nostro account to CITI-US-001',
+    createdAt: '2024-05-12T08:21:00Z',
+    ip: '10.18.31.8'
+  },
+  {
+    id: 'AUD-9932',
+    actor: 'liam@fxoption.com',
+    action: 'Manual hedge override',
+    entity: 'QT-2209',
+    metadata: 'Adjusted hedge ratio from 0.95 to 0.98',
+    createdAt: '2024-05-12T08:28:00Z',
+    ip: '10.18.31.14'
+  },
+  {
+    id: 'AUD-9933',
+    actor: 'auditor@clientbank.com',
+    action: 'Viewed payment details',
+    entity: 'PMT-444',
+    metadata: 'Read-only access granted via audit mode',
+    createdAt: '2024-05-12T08:33:00Z',
+    ip: '10.18.32.5'
+  },
+  {
+    id: 'AUD-9934',
+    actor: 'priya@fxoption.com',
+    action: 'RFQ expiry extension',
+    entity: 'QT-2207',
+    metadata: 'Expiry moved from 2m to 5m',
+    createdAt: '2024-05-12T08:45:00Z',
+    ip: '10.18.30.7'
+  }
+];

--- a/apps/admin/lib/format.ts
+++ b/apps/admin/lib/format.ts
@@ -1,0 +1,37 @@
+export function formatNotional(value: number, currency = 'USD') {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 0
+  }).format(value);
+}
+
+export function formatAmount(value: number, currency: string) {
+  const fractionDigits = ['JPY'].includes(currency) ? 0 : 2;
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: fractionDigits,
+    minimumFractionDigits: fractionDigits
+  }).format(value);
+}
+
+export function formatDate(value: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false
+  }).format(new Date(value));
+}
+
+export function formatRelativeTime(target: string) {
+  const diffMs = new Date(target).getTime() - Date.now();
+  const diffMinutes = Math.round(diffMs / 60000);
+  const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'always' });
+  if (Math.abs(diffMinutes) >= 60) {
+    const hours = Math.round(diffMinutes / 60);
+    return rtf.format(hours, 'hour');
+  }
+  return rtf.format(diffMinutes, 'minute');
+}

--- a/apps/admin/middleware.ts
+++ b/apps/admin/middleware.ts
@@ -1,0 +1,37 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import { SESSION_COOKIE_NAME, verifySessionToken } from '@/lib/auth';
+
+const PUBLIC_PATHS = ['/api/login', '/api/logout'];
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const token = request.cookies.get(SESSION_COOKIE_NAME)?.value;
+  const session = verifySessionToken(token);
+
+  if (pathname === '/login') {
+    if (session) {
+      const url = request.nextUrl.clone();
+      url.pathname = '/';
+      return NextResponse.redirect(url);
+    }
+    return NextResponse.next();
+  }
+
+  if (PUBLIC_PATHS.some((path) => pathname.startsWith(path))) {
+    return NextResponse.next();
+  }
+
+  if (!session) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/login';
+    return NextResponse.redirect(url);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)']
+};

--- a/apps/admin/next-env.d.ts
+++ b/apps/admin/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: true
+  }
+};
+
+export default nextConfig;

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "admin",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.75",
+    "@types/react-dom": "18.2.24",
+    "autoprefixer": "10.4.18",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "postcss": "8.4.38",
+    "tailwindcss": "3.4.3",
+    "typescript": "5.4.5"
+  }
+}

--- a/apps/admin/postcss.config.js
+++ b/apps/admin/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/admin/tailwind.config.ts
+++ b/apps/admin/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
+    './lib/**/*.{js,ts,jsx,tsx,mdx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};
+
+export default config;

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a new Next.js admin control room app under `apps/admin` with secure session-based login and middleware enforcement
- add dashboard, events, quotes, payments, orders, and audit views with live SSE counters plus rich search and filtering controls
- provide mock data, formatting utilities, and styled components to render operational insights across quotes, payments, hedges, and audit activity

## Testing
- npm install *(fails: 403 Forbidden when downloading @types/node from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7c71d95c832cb8081f2ba08d7502