### PR TITLE
Add dev orchestration script and gateway API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # fx-option
+
+Monorepo containing the services and user interfaces that make up the FX option experience.
+
+## One-click local environment
+
+1. **Install prerequisites**
+   - [Node.js 18+](https://nodejs.org/)
+   - [pnpm 8+](https://pnpm.io/installation)
+2. Install workspace dependencies:
+   ```bash
+   pnpm install
+   ```
+3. Launch the gateway, portal, and admin apps together:
+   ```bash
+   ./scripts/run-dev.sh
+   ```
+   The helper script coordinates the three dev servers and automatically shuts down the remaining processes when one exits.
+
+The default ports are `4000` for the gateway API, `3000` for the portal web app, and `3001` for the admin console.
+
+## Environment variables
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `GATEWAY_PORT` | Port exposed by the API gateway. | `4000` |
+| `PORTAL_WEB_PORT` | Port used by the customer-facing portal web UI. | `3000` |
+| `ADMIN_PORT` | Port used by the internal admin UI. | `3001` |
+| `DATABASE_URL` | Connection string for the transactional database. | _Required_ |
+| `FX_MARKETDATA_URL` | Base URL for upstream market data provider. | `https://marketdata.sandbox.fx-option.local` |
+| `AUTH_ISSUER_URL` | Identity provider issuer used to validate JWT access tokens. | _Required_ |
+
+Populate these variables in a `.env` file at the root of the repository or export them before starting the dev servers.
+
+## API resources
+
+- OpenAPI spec: [`docs/gateway/openapi.yaml`](docs/gateway/openapi.yaml)
+- Postman collection: [`docs/gateway/postman-collection.json`](docs/gateway/postman-collection.json)
+
+Import either file to explore gateway endpoints such as health probes, rates retrieval, quote generation, and trade booking.
+
+## Contributing
+
+1. Run the relevant checks before pushing changes:
+   ```bash
+   pnpm --filter portal-web lint
+   pnpm --filter admin lint
+   ```
+2. Open a pull request and request a review from **@codex**. Iterate on any feedback until it is fully addressed.

--- a/docs/gateway/openapi.yaml
+++ b/docs/gateway/openapi.yaml
@@ -1,0 +1,248 @@
+openapi: 3.0.3
+info:
+  title: FX Option Gateway API
+  version: 1.0.0
+  description: |
+    HTTP interface that powers pricing, quoting, and trade lifecycle flows.
+servers:
+  - url: http://localhost:4000
+    description: Local development gateway
+paths:
+  /api/v1/health:
+    get:
+      summary: Health probe
+      description: Lightweight ping endpoint used by orchestrators and monitoring.
+      responses:
+        '200':
+          description: Gateway is healthy.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+  /api/v1/rates:
+    get:
+      summary: Retrieve current FX option volatility surface and spot rates.
+      parameters:
+        - in: query
+          name: baseCurrency
+          required: true
+          schema:
+            type: string
+            example: EUR
+        - in: query
+          name: quoteCurrency
+          required: true
+          schema:
+            type: string
+            example: USD
+        - in: query
+          name: tenor
+          schema:
+            type: string
+            example: 1M
+          description: Optional tenor filter in ISO 8601 duration format.
+      responses:
+        '200':
+          description: Collection of market data snapshots for the requested currency pair.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RatesResponse'
+  /api/v1/quotes:
+    post:
+      summary: Generate indicative option quote.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuoteRequest'
+      responses:
+        '200':
+          description: Indicative quote successfully generated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuoteResponse'
+        '422':
+          description: Invalid pricing parameters supplied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/trades:
+    post:
+      summary: Book a new FX option trade using a previously accepted quote.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TradeRequest'
+      responses:
+        '201':
+          description: Trade successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TradeResponse'
+        '409':
+          description: Quote already consumed or expired.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  schemas:
+    HealthResponse:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          example: ok
+        uptimeSeconds:
+          type: integer
+          example: 123
+    RatesResponse:
+      type: object
+      required:
+        - baseCurrency
+        - quoteCurrency
+        - spotRate
+        - volatilitySurface
+      properties:
+        baseCurrency:
+          type: string
+          example: EUR
+        quoteCurrency:
+          type: string
+          example: USD
+        spotRate:
+          type: number
+          format: float
+          example: 1.0985
+        volatilitySurface:
+          type: array
+          items:
+            $ref: '#/components/schemas/VolatilityNode'
+    VolatilityNode:
+      type: object
+      required:
+        - tenor
+        - delta
+        - volatility
+      properties:
+        tenor:
+          type: string
+          description: ISO 8601 tenor label (e.g. 1M, 3M, 1Y).
+        delta:
+          type: number
+          format: float
+          description: Option delta bucket (e.g. 0.25).
+        volatility:
+          type: number
+          format: float
+          description: Implied volatility percentage.
+          example: 0.124
+    QuoteRequest:
+      type: object
+      required:
+        - baseCurrency
+        - quoteCurrency
+        - notional
+        - direction
+        - expiry
+        - optionType
+      properties:
+        baseCurrency:
+          type: string
+          example: EUR
+        quoteCurrency:
+          type: string
+          example: USD
+        notional:
+          type: number
+          format: float
+          example: 1000000
+        direction:
+          type: string
+          enum: [BUY, SELL]
+        expiry:
+          type: string
+          format: date
+          example: 2024-12-20
+        optionType:
+          type: string
+          enum: [CALL, PUT]
+        strike:
+          type: number
+          format: float
+          example: 1.1
+    QuoteResponse:
+      type: object
+      required:
+        - quoteId
+        - premium
+        - expiration
+      properties:
+        quoteId:
+          type: string
+          format: uuid
+        premium:
+          type: number
+          format: float
+          description: Premium amount denominated in the quote currency.
+          example: 12345.67
+        expiration:
+          type: string
+          format: date-time
+          description: Expiration timestamp for quote acceptance.
+        marketDataTimestamp:
+          type: string
+          format: date-time
+    TradeRequest:
+      type: object
+      required:
+        - quoteId
+        - traderId
+      properties:
+        quoteId:
+          type: string
+          format: uuid
+        traderId:
+          type: string
+          example: T12345
+    TradeResponse:
+      type: object
+      required:
+        - tradeId
+        - quoteId
+        - status
+      properties:
+        tradeId:
+          type: string
+          format: uuid
+        quoteId:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [PENDING, CONFIRMED]
+        bookedAt:
+          type: string
+          format: date-time
+    ErrorResponse:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+        code:
+          type: string
+        details:
+          type: array
+          items:
+            type: string

--- a/docs/gateway/postman-collection.json
+++ b/docs/gateway/postman-collection.json
@@ -1,0 +1,116 @@
+{
+  "info": {
+    "_postman_id": "b6be9936-65ac-4bd1-8ed1-0d1c9d9d0001",
+    "name": "FX Option Gateway",
+    "description": "Sample requests for common FX Option gateway workflows.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Health",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{gateway_base_url}}/api/v1/health",
+          "host": [
+            "{{gateway_base_url}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "health"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Fetch Rates",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{gateway_base_url}}/api/v1/rates?baseCurrency=EUR&quoteCurrency=USD",
+          "host": [
+            "{{gateway_base_url}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "rates"
+          ],
+          "query": [
+            {
+              "key": "baseCurrency",
+              "value": "EUR"
+            },
+            {
+              "key": "quoteCurrency",
+              "value": "USD"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Create Quote",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"baseCurrency\": \"EUR\",\n  \"quoteCurrency\": \"USD\",\n  \"notional\": 1000000,\n  \"direction\": \"BUY\",\n  \"expiry\": \"2024-12-20\",\n  \"optionType\": \"CALL\",\n  \"strike\": 1.1\n}"
+        },
+        "url": {
+          "raw": "{{gateway_base_url}}/api/v1/quotes",
+          "host": [
+            "{{gateway_base_url}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "quotes"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Book Trade",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"quoteId\": \"11111111-2222-3333-4444-555555555555\",\n  \"traderId\": \"T12345\"\n}"
+        },
+        "url": {
+          "raw": "{{gateway_base_url}}/api/v1/trades",
+          "host": [
+            "{{gateway_base_url}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "trades"
+          ]
+        }
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "gateway_base_url",
+      "value": "http://localhost:4000"
+    }
+  ]
+}

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+COMMANDS=(
+  "pnpm --filter gateway dev"
+  "pnpm --filter portal-web dev"
+  "pnpm --filter admin dev"
+)
+
+PIDS=()
+
+cleanup() {
+  local exit_code=$?
+  for pid in "${PIDS[@]:-}"; do
+    if kill -0 "$pid" >/dev/null 2>&1; then
+      kill "$pid" >/dev/null 2>&1 || true
+    fi
+  done
+  wait >/dev/null 2>&1 || true
+  return $exit_code
+}
+
+trap cleanup EXIT INT TERM
+
+for cmd in "${COMMANDS[@]}"; do
+  (
+    cd "$ROOT_DIR"
+    echo "Starting $cmd"
+    eval "$cmd"
+  ) &
+  PIDS+=("$!")
+  sleep 1
+done
+
+# Wait for first process to exit and propagate status
+status=0
+for pid in "${PIDS[@]}"; do
+  if wait "$pid"; then
+    continue
+  else
+    status=$?
+    echo "Process $pid exited with status $status" >&2
+    break
+  fi
+done
+
+if [ $status -ne 0 ]; then
+  echo "Stopping remaining services..." >&2
+  cleanup
+fi
+
+exit $status


### PR DESCRIPTION
## Summary
- add a reusable `scripts/run-dev.sh` helper that launches the gateway, portal, and admin dev servers together
- document environment setup and link to new gateway OpenAPI and Postman assets in the README
- provide formal API documentation artifacts for the gateway endpoints to streamline onboarding

## Testing
- pnpm --filter portal-web lint
- pnpm --filter admin lint

------
https://chatgpt.com/codex/tasks/task_e_68ce608172dc832ca6c376255d860d83