### PR TITLE
docs: add onboarding assets and dev helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
 # fx-option
+
+This monorepo hosts the FX Option experience, including the public client portal, the internal
+admin console, and the gateway that mediates traffic between them and downstream services.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) 18+
+- [pnpm](https://pnpm.io/) 8+
+
+## One-click local stack
+
+Use the helper script to spin up the entire stack after installing dependencies:
+
+```bash
+pnpm install
+./scripts/run-dev.sh
+```
+
+The script launches the gateway, portal, and admin applications concurrently using `pnpm dlx concurrently`.
+Logs are color coded so you can quickly spot which service produced each line. Stop everything with `Ctrl+C`.
+
+## Manual commands
+
+Each application can still be started individually if you prefer:
+
+```bash
+pnpm --filter gateway dev
+pnpm --filter portal-web dev
+pnpm --filter admin dev
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `GATEWAY_PORT` | `4000` | Port for the local gateway HTTP server. |
+| `GATEWAY_LOG_LEVEL` | `info` | Logging verbosity for the gateway. |
+| `PORTAL_API_URL` | `http://localhost:4000` | URL used by the customer-facing portal when calling the gateway. |
+| `ADMIN_API_URL` | `http://localhost:4000` | URL used by the internal admin console when calling the gateway. |
+| `AUTH_ISSUER_URL` | _(required)_ | OIDC issuer used by the portal and admin applications. |
+| `AUTH_CLIENT_ID` | _(required)_ | OAuth client ID shared across SPA front-ends. |
+| `AUTH_CLIENT_SECRET` | _(optional)_ | Backend credential for privileged automation (only needed server-side). |
+| `SENTRY_DSN` | _(optional)_ | Enables error reporting when defined. |
+
+Store secrets such as `AUTH_CLIENT_SECRET` in a `.env.local` file instead of committing them.
+
+## API assets
+
+Generated assets documenting the gateway endpoints live in [`docs/api`](docs/api):
+
+- [`gateway-openapi.yaml`](docs/api/gateway-openapi.yaml) – OpenAPI 3.1 description for use with Swagger UI or Stoplight.
+- [`gateway.postman_collection.json`](docs/api/gateway.postman_collection.json) – Postman collection for quick manual testing.
+
+Import either artifact into your favorite tool to explore the available endpoints.
+
+## Linting
+
+Run the portal and admin lint checks before opening a pull request:
+
+```bash
+pnpm --filter portal-web lint
+pnpm --filter admin lint
+```
+
+These commands are also executed automatically in CI. If the filters do not match any packages,
+verify that you ran the commands from the monorepo root.

--- a/docs/api/gateway-openapi.yaml
+++ b/docs/api/gateway-openapi.yaml
@@ -1,0 +1,271 @@
+openapi: 3.1.0
+info:
+  title: FX Option Gateway API
+  version: 1.0.0
+  description: |
+    REST API that powers the FX Option gateway. The gateway orchestrates requests between
+    the public web portal, the internal admin console, and downstream pricing/booking
+    services.
+servers:
+  - url: http://localhost:4000
+    description: Local development gateway
+  - url: https://api.fx-option.dev
+    description: Shared staging gateway
+paths:
+  /health:
+    get:
+      summary: Gateway health check
+      operationId: getHealth
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+  /v1/quotes:
+    get:
+      summary: Retrieve latest quote snapshot
+      operationId: listQuotes
+      parameters:
+        - in: query
+          name: currencyPair
+          schema:
+            type: string
+            example: EURUSD
+          description: Restrict results to a single currency pair (e.g. EURUSD)
+        - in: query
+          name: tenor
+          schema:
+            type: string
+            example: 1M
+          description: Optional tenor filter (e.g. 1M, 3M)
+      responses:
+        '200':
+          description: Collection of quotes
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Quote'
+    post:
+      summary: Request an executable quote
+      operationId: requestQuote
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuoteRequest'
+      responses:
+        '201':
+          description: Executable quote created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Quote'
+        '422':
+          description: Invalid payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /v1/trades:
+    post:
+      summary: Book an option trade
+      operationId: bookTrade
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TradeRequest'
+      responses:
+        '201':
+          description: Trade created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Trade'
+        '409':
+          description: Quote has expired
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /v1/trades/{tradeId}:
+    get:
+      summary: Retrieve a trade by identifier
+      operationId: getTrade
+      parameters:
+        - in: path
+          name: tradeId
+          required: true
+          schema:
+            type: string
+          description: Identifier returned by the bookTrade endpoint
+      responses:
+        '200':
+          description: Trade found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Trade'
+        '404':
+          description: Trade not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /v1/rates:
+    get:
+      summary: Retrieve market data used for pricing
+      operationId: listRates
+      responses:
+        '200':
+          description: Market data snapshot
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Rate'
+components:
+  schemas:
+    HealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: ok
+        time:
+          type: string
+          format: date-time
+    QuoteRequest:
+      type: object
+      required:
+        - currencyPair
+        - side
+        - notional
+        - tenor
+      properties:
+        currencyPair:
+          type: string
+          example: EURUSD
+        side:
+          type: string
+          enum: [BUY, SELL]
+        notional:
+          type: number
+          format: double
+          example: 1000000
+        tenor:
+          type: string
+          example: 3M
+        optionType:
+          type: string
+          enum: [CALL, PUT]
+        strike:
+          type: number
+          format: double
+          example: 1.0925
+    Quote:
+      type: object
+      required:
+        - id
+        - expiresAt
+        - premium
+        - currencyPair
+        - tenor
+      properties:
+        id:
+          type: string
+          example: q-01H8G7SV3C4YZ9
+        currencyPair:
+          type: string
+        tenor:
+          type: string
+        premium:
+          type: number
+          format: double
+        premiumCurrency:
+          type: string
+          example: USD
+        expiresAt:
+          type: string
+          format: date-time
+        spot:
+          type: number
+          format: double
+        strike:
+          type: number
+          format: double
+    TradeRequest:
+      type: object
+      required:
+        - quoteId
+        - book
+      properties:
+        quoteId:
+          type: string
+        book:
+          type: string
+          example: LDN_EQD
+        counterpartyReference:
+          type: string
+        notes:
+          type: string
+    Trade:
+      type: object
+      required:
+        - id
+        - quoteId
+        - bookedAt
+        - status
+      properties:
+        id:
+          type: string
+          example: t-01H8G7WABCXYZ
+        quoteId:
+          type: string
+        status:
+          type: string
+          enum: [PENDING, BOOKED, REJECTED]
+        bookedAt:
+          type: string
+          format: date-time
+        settlementDate:
+          type: string
+          format: date
+        trader:
+          type: string
+          example: jdoe
+    Rate:
+      type: object
+      required:
+        - currencyPair
+        - tenor
+        - forward
+      properties:
+        currencyPair:
+          type: string
+        tenor:
+          type: string
+        forward:
+          type: number
+          format: double
+        vol:
+          type: number
+          format: double
+    ErrorResponse:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          example: Quote has expired
+        code:
+          type: string
+          example: QUOTE_EXPIRED

--- a/docs/api/gateway.postman_collection.json
+++ b/docs/api/gateway.postman_collection.json
@@ -1,0 +1,138 @@
+{
+  "info": {
+    "name": "FX Option Gateway",
+    "description": "Collection targeting the FX Option gateway used by the portal and admin apps.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "version": "1.0.0"
+  },
+  "item": [
+    {
+      "name": "Health",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{gateway_base_url}}/health",
+          "host": ["{{gateway_base_url}}"],
+          "path": ["health"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "List Quotes",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{gateway_base_url}}/v1/quotes?currencyPair=EURUSD",
+          "host": ["{{gateway_base_url}}"],
+          "path": ["v1", "quotes"],
+          "query": [
+            {
+              "key": "currencyPair",
+              "value": "EURUSD"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Request Quote",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"currencyPair\": \"EURUSD\",\n  \"side\": \"BUY\",\n  \"notional\": 1000000,\n  \"tenor\": \"3M\",\n  \"optionType\": \"CALL\"\n}"
+        },
+        "url": {
+          "raw": "{{gateway_base_url}}/v1/quotes",
+          "host": ["{{gateway_base_url}}"],
+          "path": ["v1", "quotes"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Book Trade",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"quoteId\": \"q-01H8G7SV3C4YZ9\",\n  \"book\": \"LDN_EQD\"\n}"
+        },
+        "url": {
+          "raw": "{{gateway_base_url}}/v1/trades",
+          "host": ["{{gateway_base_url}}"],
+          "path": ["v1", "trades"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Get Trade",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{gateway_base_url}}/v1/trades/{{trade_id}}",
+          "host": ["{{gateway_base_url}}"],
+          "path": ["v1", "trades", "{{trade_id}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "List Rates",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{gateway_base_url}}/v1/rates",
+          "host": ["{{gateway_base_url}}"],
+          "path": ["v1", "rates"]
+        }
+      },
+      "response": []
+    }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": []
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": []
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "gateway_base_url",
+      "value": "http://localhost:4000"
+    },
+    {
+      "key": "trade_id",
+      "value": "t-01H8G7WABCXYZ"
+    }
+  ]
+}

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "Error: pnpm is required but was not found in PATH." >&2
+  echo "Install pnpm from https://pnpm.io/installation and re-run this script." >&2
+  exit 1
+fi
+
+cd "$REPO_ROOT"
+
+if [ ! -f "pnpm-lock.yaml" ]; then
+  echo "Warning: pnpm-lock.yaml not found. Have you run 'pnpm install'?" >&2
+fi
+
+PNPM_EXECUTABLE="pnpm"
+
+# shellcheck disable=SC2086
+$PNPM_EXECUTABLE dlx concurrently \
+  --kill-others-on-fail \
+  --names "gateway,portal,admin" \
+  --prefix-colors "cyan.bold,magenta.bold,green.bold" \
+  "pnpm --filter gateway dev" \
+  "pnpm --filter portal-web dev" \
+  "pnpm --filter admin dev"


### PR DESCRIPTION
## Summary
- add a helper script for launching gateway, portal, and admin together via pnpm
- document gateway endpoints with OpenAPI and Postman assets in docs/api
- expand the README with quick start steps and environment variable guidance

## Testing
- pnpm --filter portal-web lint
- pnpm --filter admin lint

------
https://chatgpt.com/codex/tasks/task_e_68ce60713338832c8bfdf7be101b2ea7