### PR TITLE
Add CI workflow for pnpm and python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Install, lint, build, and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build ui-kit
+        run: pnpm --filter ui-kit build
+
+      - name: Lint portal-web
+        run: pnpm --filter portal-web lint
+
+      - name: Build portal-web
+        run: pnpm --filter portal-web build
+
+      - name: Lint admin
+        run: pnpm --filter admin lint
+
+      - name: Build admin
+        run: pnpm --filter admin build
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            **/requirements*.txt
+
+      - name: Run Python tests
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          python -m pytest


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to install dependencies, lint, build, and test the project
- configure pnpm and pip caching to speed up repeated runs

## Testing
- No tests were run (not requested)

Tagging @codex for review.

------
https://chatgpt.com/codex/tasks/task_e_68ce605c9100832c972bdda3315286fb