### PR TITLE
feat: add richer risk reporting domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/risk_reporting/__init__.py
+++ b/risk_reporting/__init__.py
@@ -1,0 +1,15 @@
+"""Risk reporting domain package."""
+
+from .models import Trade, RiskReport
+from .service import RiskService
+from .gateway import RiskGateway
+from .consumers import PortalConsumer, AdminConsumer
+
+__all__ = [
+    "Trade",
+    "RiskReport",
+    "RiskService",
+    "RiskGateway",
+    "PortalConsumer",
+    "AdminConsumer",
+]

--- a/risk_reporting/consumers.py
+++ b/risk_reporting/consumers.py
@@ -1,0 +1,50 @@
+"""Consumers that adapt the risk report for UI surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+from .models import RiskReport
+
+
+@dataclass
+class PortalConsumer:
+    """Prepare data for the customer facing portal."""
+
+    def build_view_model(self, report: RiskReport) -> Dict[str, object]:
+        return {
+            "headline": {
+                "grossExposure": report.gross_exposure,
+                "netExposure": report.net_exposure,
+                "valueAtRisk": report.value_at_risk,
+            },
+            "deltaBreakdown": report.delta_breakdown,
+            "savings": report.savings_percentages,
+        }
+
+
+@dataclass
+class AdminConsumer:
+    """Prepare data for internal admin tooling."""
+
+    def build_view_model(self, report: RiskReport) -> Dict[str, object]:
+        rows = []
+        for currency, delta in report.delta_breakdown.items():
+            rows.append(
+                {
+                    "currency": currency,
+                    "delta": delta,
+                    "savingsPct": report.savings_percentages.get(currency, 0.0),
+                }
+            )
+        rows.sort(key=lambda item: item["currency"])
+        return {
+            "summary": {
+                "grossExposure": report.gross_exposure,
+                "netExposure": report.net_exposure,
+                "valueAtRisk": report.value_at_risk,
+                "portfolioSavings": report.savings_percentages.get("portfolio", 0.0),
+            },
+            "rows": rows,
+        }

--- a/risk_reporting/gateway.py
+++ b/risk_reporting/gateway.py
@@ -1,0 +1,31 @@
+"""Gateway layer that exposes the risk report through an API friendly payload."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .models import RiskReport, Trade
+from .service import RiskService
+
+
+class RiskGateway:
+    """Compose the risk report for downstream services."""
+
+    def __init__(self, service: RiskService | None = None) -> None:
+        self._service = service or RiskService()
+
+    def build_payload(self, trades: Iterable[Trade]) -> dict:
+        """Return a dictionary payload ready to be serialised to JSON."""
+
+        report = self._service.generate_report(trades)
+        payload = report.to_dict()
+        payload["metadata"] = {
+            "confidence": self._service._confidence,
+            "z_score": self._service._z_score,
+        }
+        return payload
+
+    def report_for_trade_ids(self, trades: Iterable[Trade]) -> RiskReport:
+        """Proxy around :meth:`RiskService.generate_report` for convenience."""
+
+        return self._service.generate_report(trades)

--- a/risk_reporting/models.py
+++ b/risk_reporting/models.py
@@ -1,0 +1,64 @@
+"""Domain models used by the risk reporting service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class Trade:
+    """Represents a simplified FX option trade.
+
+    Attributes
+    ----------
+    trade_id:
+        Unique identifier for the trade.
+    currency:
+        Currency ISO code of the trade exposure.
+    notional:
+        Notional size of the trade in the foreign currency.
+    spot_rate:
+        Spot FX rate used to convert the notional into the base currency.
+    delta:
+        Sensitivity of the trade value to changes in the underlying spot price.
+    volatility:
+        Annualised volatility estimate for the underlying asset.
+    hedge_ratio:
+        Value between 0 and 1 indicating the level of hedging applied.
+    """
+
+    trade_id: str
+    currency: str
+    notional: float
+    spot_rate: float
+    delta: float
+    volatility: float
+    hedge_ratio: float = 0.0
+
+    def exposure(self) -> float:
+        """Return the base currency exposure of the trade."""
+
+        return self.notional * self.spot_rate
+
+
+@dataclass(frozen=True)
+class RiskReport:
+    """Aggregated metrics produced by :class:`RiskService`."""
+
+    gross_exposure: float
+    net_exposure: float
+    value_at_risk: float
+    delta_breakdown: Dict[str, float] = field(default_factory=dict)
+    savings_percentages: Dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, float]:
+        """Serialize report into a dictionary that can be served externally."""
+
+        return {
+            "gross_exposure": self.gross_exposure,
+            "net_exposure": self.net_exposure,
+            "value_at_risk": self.value_at_risk,
+            "delta_breakdown": dict(self.delta_breakdown),
+            "savings_percentages": dict(self.savings_percentages),
+        }

--- a/risk_reporting/service.py
+++ b/risk_reporting/service.py
@@ -1,0 +1,119 @@
+"""Core risk analytics used by the reporting stack."""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from typing import Dict, Iterable, Tuple
+
+from .models import RiskReport, Trade
+
+
+class RiskService:
+    """Aggregate risk metrics for a collection of trades.
+
+    The implementation intentionally keeps the analytics deterministic and
+    dependency free so it can be executed in a unit test environment.
+    """
+
+    def __init__(self, confidence: float = 0.95) -> None:
+        if not 0 < confidence < 1:
+            raise ValueError("confidence must be between 0 and 1")
+        self._confidence = confidence
+        # Convert confidence to the appropriate z-score for a normal
+        # distribution. We only need the upper tail.
+        self._z_score = self._confidence_to_z_score(confidence)
+
+    @staticmethod
+    def _confidence_to_z_score(confidence: float) -> float:
+        # Lookup table for common confidence levels. Falls back to the
+        # inverse error function for other values.
+        lookups = {0.90: 1.2816, 0.95: 1.6449, 0.99: 2.3263}
+        if confidence in lookups:
+            return lookups[confidence]
+        # Fallback using erfcinv so we do not depend on scipy.
+        return math.sqrt(2) * math.erfcinv(2 * (1 - confidence))
+
+    def generate_report(self, trades: Iterable[Trade]) -> RiskReport:
+        """Return a :class:`RiskReport` describing the supplied trades."""
+
+        trade_list = list(trades)
+        if not trade_list:
+            return RiskReport(0.0, 0.0, 0.0, {}, {})
+
+        gross, net = self._compute_exposure(trade_list)
+        hedged_var, baseline_var, var_by_ccy = self._compute_var(trade_list)
+        delta_breakdown = self._compute_delta_breakdown(trade_list)
+        savings_percentages = self._compute_savings_percentages(
+            hedged_var, baseline_var, var_by_ccy
+        )
+        return RiskReport(
+            gross_exposure=gross,
+            net_exposure=net,
+            value_at_risk=hedged_var,
+            delta_breakdown=delta_breakdown,
+            savings_percentages=savings_percentages,
+        )
+
+    def _compute_exposure(self, trades: Iterable[Trade]) -> Tuple[float, float]:
+        gross = 0.0
+        net = 0.0
+        for trade in trades:
+            exposure = trade.exposure()
+            gross += abs(exposure)
+            net += exposure
+        return gross, net
+
+    def _compute_var(
+        self, trades: Iterable[Trade]
+    ) -> Tuple[float, float, Dict[str, Tuple[float, float]]]:
+        """Return hedged portfolio VaR, baseline VaR and per currency values."""
+
+        variance_hedged = 0.0
+        variance_baseline = 0.0
+        variance_by_ccy: Dict[str, Tuple[float, float]] = defaultdict(lambda: [0.0, 0.0])
+        for trade in trades:
+            base = trade.exposure() * trade.delta * trade.volatility
+            baseline_component = base
+            hedged_component = base * (1 - trade.hedge_ratio)
+            variance_baseline += baseline_component**2
+            variance_hedged += hedged_component**2
+            bucket = variance_by_ccy[trade.currency]
+            bucket[0] += hedged_component**2
+            bucket[1] += baseline_component**2
+        hedged_var = self._z_score * math.sqrt(variance_hedged)
+        baseline_var = self._z_score * math.sqrt(variance_baseline)
+        per_currency = {
+            currency: (
+                self._z_score * math.sqrt(hedged),
+                self._z_score * math.sqrt(baseline),
+            )
+            for currency, (hedged, baseline) in variance_by_ccy.items()
+        }
+        return hedged_var, baseline_var, per_currency
+
+    def _compute_delta_breakdown(self, trades: Iterable[Trade]) -> Dict[str, float]:
+        breakdown: Dict[str, float] = defaultdict(float)
+        for trade in trades:
+            breakdown[trade.currency] += trade.notional * trade.delta
+        return dict(sorted(breakdown.items()))
+
+    def _compute_savings_percentages(
+        self,
+        hedged_var: float,
+        baseline_var: float,
+        var_by_ccy: Dict[str, Tuple[float, float]],
+    ) -> Dict[str, float]:
+        """Compute savings percentages overall and by currency."""
+
+        savings: Dict[str, float] = {}
+        savings["portfolio"] = self._savings_pct(hedged_var, baseline_var)
+        for currency, (hedged, baseline) in var_by_ccy.items():
+            savings[currency] = self._savings_pct(hedged, baseline)
+        return dict(sorted(savings.items()))
+
+    @staticmethod
+    def _savings_pct(hedged: float, baseline: float) -> float:
+        if baseline == 0:
+            return 0.0
+        return (baseline - hedged) / baseline * 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_risk_service.py
+++ b/tests/test_risk_service.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from risk_reporting import (
+    AdminConsumer,
+    PortalConsumer,
+    RiskGateway,
+    RiskReport,
+    RiskService,
+    Trade,
+)
+
+
+@pytest.fixture
+def sample_trades() -> list[Trade]:
+    return [
+        Trade(
+            trade_id="T1",
+            currency="USD",
+            notional=1_000_000,
+            spot_rate=1.0,
+            delta=0.45,
+            volatility=0.12,
+            hedge_ratio=0.3,
+        ),
+        Trade(
+            trade_id="T2",
+            currency="EUR",
+            notional=-800_000,
+            spot_rate=1.1,
+            delta=0.55,
+            volatility=0.18,
+            hedge_ratio=0.5,
+        ),
+        Trade(
+            trade_id="T3",
+            currency="USD",
+            notional=500_000,
+            spot_rate=1.0,
+            delta=-0.25,
+            volatility=0.2,
+            hedge_ratio=0.1,
+        ),
+    ]
+
+
+def test_service_adds_richer_metrics(sample_trades: list[Trade]) -> None:
+    service = RiskService()
+    report = service.generate_report(sample_trades)
+
+    assert isinstance(report, RiskReport)
+    assert report.gross_exposure == pytest.approx(2_380_000)
+    assert report.net_exposure == pytest.approx(620_000)
+    assert report.value_at_risk == pytest.approx(101_831.979, rel=1e-6)
+    assert report.delta_breakdown == {
+        "EUR": pytest.approx(-440_000),
+        "USD": pytest.approx(325_000),
+    }
+
+    expected_savings = {
+        "EUR": pytest.approx(50.0),
+        "USD": pytest.approx(26.0756, rel=1e-4),
+        "portfolio": pytest.approx(41.3214, rel=1e-4),
+    }
+    assert report.savings_percentages.keys() == expected_savings.keys()
+    for key in expected_savings:
+        assert report.savings_percentages[key] == expected_savings[key]
+
+
+def test_gateway_payload_exposes_new_fields(sample_trades: list[Trade]) -> None:
+    payload = RiskGateway().build_payload(sample_trades)
+    assert payload["value_at_risk"] == pytest.approx(101_831.979, rel=1e-6)
+    assert payload["delta_breakdown"]["EUR"] == pytest.approx(-440_000)
+    assert payload["delta_breakdown"]["USD"] == pytest.approx(325_000)
+    assert payload["savings_percentages"]["portfolio"] == pytest.approx(
+        41.3214, rel=1e-4
+    )
+    assert "metadata" in payload
+    assert math.isclose(payload["metadata"]["confidence"], 0.95)
+    assert payload["metadata"]["z_score"] == pytest.approx(1.6449, rel=1e-4)
+
+
+def test_portal_consumer_surfaces_var_and_savings(sample_trades: list[Trade]) -> None:
+    report = RiskService().generate_report(sample_trades)
+    model = PortalConsumer().build_view_model(report)
+    assert model["headline"]["valueAtRisk"] == pytest.approx(101_831.979, rel=1e-6)
+    assert model["deltaBreakdown"]["EUR"] == pytest.approx(-440_000)
+    assert model["savings"]["portfolio"] == pytest.approx(41.3214, rel=1e-4)
+
+
+def test_admin_consumer_includes_delta_and_savings(sample_trades: list[Trade]) -> None:
+    report = RiskService().generate_report(sample_trades)
+    model = AdminConsumer().build_view_model(report)
+
+    assert model["summary"]["valueAtRisk"] == pytest.approx(101_831.979, rel=1e-6)
+    assert model["summary"]["portfolioSavings"] == pytest.approx(41.3214, rel=1e-4)
+
+    usd_row = next(row for row in model["rows"] if row["currency"] == "USD")
+    eur_row = next(row for row in model["rows"] if row["currency"] == "EUR")
+
+    assert usd_row == {
+        "currency": "USD",
+        "delta": pytest.approx(325_000),
+        "savingsPct": pytest.approx(26.0756, rel=1e-4),
+    }
+    assert eur_row == {
+        "currency": "EUR",
+        "delta": pytest.approx(-440_000),
+        "savingsPct": pytest.approx(50.0),
+    }


### PR DESCRIPTION
## Summary
- implement a standalone risk reporting domain that calculates VaR, delta breakdown and hedging savings
- expose the expanded metrics via the gateway payload and dedicated portal/admin consumers
- cover the richer reporting with focused unit tests

## Testing
- pytest tests/test_risk_service.py

cc @codex

------
https://chatgpt.com/codex/tasks/task_e_68ce6050053c832cbe614bef8e1911f6