### PR TITLE
Add Black-Scholes pricing orchestrator and expose metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+node_modules/

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,3 @@
+"""Service package root for fx-option back-end components."""
+
+__all__: list[str] = []

--- a/services/pricing-orchestrator/tests/test_orchestrator.py
+++ b/services/pricing-orchestrator/tests/test_orchestrator.py
@@ -1,0 +1,108 @@
+"""Tests for the pricing orchestrator."""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from services.pricing_orchestrator import (  # noqa: E402  pylint: disable=wrong-import-position
+    QuoteOrchestrator,
+    QuoteRequest,
+    bind_quote_endpoint,
+)
+
+
+@dataclass
+class DummyEngine:
+    quoted_value: float
+    metadata_payload: Dict[str, str]
+
+    def price(
+        self,
+        *,
+        spot: float,
+        strike: float,
+        volatility: float,
+        rate: float,
+        time_to_expiry: float,
+        option_type: str = "call",
+    ) -> float:
+        self.last_price_args = {
+            "spot": spot,
+            "strike": strike,
+            "volatility": volatility,
+            "rate": rate,
+            "time_to_expiry": time_to_expiry,
+            "option_type": option_type,
+        }
+        return self.quoted_value
+
+    def metadata(self) -> Dict[str, str]:
+        return self.metadata_payload
+
+
+def test_orchestrator_uses_injected_engine() -> None:
+    engine = DummyEngine(quoted_value=42.0, metadata_payload={"name": "dummy"})
+    orchestrator = QuoteOrchestrator(pricing_engine=engine)
+    request = QuoteRequest(
+        spot=101.0,
+        strike=100.0,
+        volatility=0.2,
+        rate=0.01,
+        time_to_expiry=0.5,
+        option_type="call",
+    )
+
+    response = orchestrator.generate_quote(request)
+
+    assert response.price == pytest.approx(42.0)
+    assert response.pricing_model == engine.metadata_payload
+    assert engine.last_price_args["spot"] == pytest.approx(101.0)
+
+
+def test_black_scholes_engine_matches_reference_value() -> None:
+    orchestrator = QuoteOrchestrator()
+    request = QuoteRequest(
+        spot=100.0,
+        strike=100.0,
+        volatility=0.2,
+        rate=0.05,
+        time_to_expiry=1.0,
+        option_type="call",
+    )
+
+    response = orchestrator.generate_quote(request)
+
+    reference_price = 10.4506
+    assert response.price == pytest.approx(reference_price, rel=1e-3)
+    assert response.pricing_model["name"] == "Black-Scholes"
+
+
+def test_gateway_includes_pricing_metadata() -> None:
+    engine = DummyEngine(
+        quoted_value=12.5,
+        metadata_payload={"name": "dummy", "version": "test"},
+    )
+    orchestrator = QuoteOrchestrator(pricing_engine=engine)
+    endpoint = bind_quote_endpoint(orchestrator)
+
+    payload = {
+        "spot": 100.0,
+        "strike": 90.0,
+        "volatility": 0.3,
+        "rate": 0.01,
+        "time_to_expiry": 0.25,
+    }
+
+    response = endpoint(payload)
+
+    assert response["price"] == pytest.approx(12.5)
+    assert response["pricingModel"] == engine.metadata_payload

--- a/services/pricing_orchestrator/__init__.py
+++ b/services/pricing_orchestrator/__init__.py
@@ -1,0 +1,14 @@
+"""Pricing orchestrator service package."""
+
+from .pricing_engine import BlackScholesPricingEngine, PricingEngine
+from .orchestrator import QuoteOrchestrator, QuoteRequest, QuoteResponse
+from .gateway import bind_quote_endpoint
+
+__all__ = [
+    "BlackScholesPricingEngine",
+    "PricingEngine",
+    "QuoteOrchestrator",
+    "QuoteRequest",
+    "QuoteResponse",
+    "bind_quote_endpoint",
+]

--- a/services/pricing_orchestrator/gateway.py
+++ b/services/pricing_orchestrator/gateway.py
@@ -1,0 +1,20 @@
+"""Gateway bindings for the pricing orchestrator."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+from .orchestrator import QuoteOrchestrator
+
+
+def bind_quote_endpoint(orchestrator: QuoteOrchestrator):
+    """Return a callable endpoint that creates quotes via the orchestrator."""
+
+    def quote_endpoint(payload: Mapping[str, Any]) -> Dict[str, Any]:
+        response = orchestrator.generate_quote_from_payload(dict(payload))
+        return {
+            "price": response.price,
+            "pricingModel": response.pricing_model,
+        }
+
+    return quote_endpoint

--- a/services/pricing_orchestrator/orchestrator.py
+++ b/services/pricing_orchestrator/orchestrator.py
@@ -1,0 +1,54 @@
+"""Quote orchestration logic."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from .pricing_engine import BlackScholesPricingEngine, PricingEngine
+
+
+@dataclass(frozen=True)
+class QuoteRequest:
+    """Input parameters required to price an option."""
+
+    spot: float
+    strike: float
+    volatility: float
+    rate: float
+    time_to_expiry: float
+    option_type: str = "call"
+
+
+@dataclass(frozen=True)
+class QuoteResponse:
+    """Response returned by the orchestrator."""
+
+    price: float
+    pricing_model: Dict[str, Any]
+
+
+class QuoteOrchestrator:
+    """Coordinates the pricing of FX option quotes."""
+
+    def __init__(self, pricing_engine: Optional[PricingEngine] = None) -> None:
+        self._pricing_engine = pricing_engine or BlackScholesPricingEngine()
+
+    @property
+    def pricing_engine(self) -> PricingEngine:
+        return self._pricing_engine
+
+    def generate_quote(self, request: QuoteRequest) -> QuoteResponse:
+        price = self._pricing_engine.price(
+            spot=request.spot,
+            strike=request.strike,
+            volatility=request.volatility,
+            rate=request.rate,
+            time_to_expiry=request.time_to_expiry,
+            option_type=request.option_type,
+        )
+        return QuoteResponse(price=price, pricing_model=self._pricing_engine.metadata())
+
+    def generate_quote_from_payload(self, payload: Dict[str, Any]) -> QuoteResponse:
+        request = QuoteRequest(**payload)
+        return self.generate_quote(request)

--- a/services/pricing_orchestrator/pricing_engine.py
+++ b/services/pricing_orchestrator/pricing_engine.py
@@ -1,0 +1,86 @@
+"""Pricing engine implementations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Dict, Protocol
+
+
+class PricingEngine(Protocol):
+    """Protocol describing a pricing engine."""
+
+    def price(
+        self,
+        *,
+        spot: float,
+        strike: float,
+        volatility: float,
+        rate: float,
+        time_to_expiry: float,
+        option_type: str = "call",
+    ) -> float:
+        """Return the price of an option for the provided parameters."""
+
+    def metadata(self) -> Dict[str, str]:
+        """Return metadata describing the pricing model."""
+
+
+@dataclass(slots=True)
+class BlackScholesPricingEngine:
+    """Simplified Black-Scholes pricing engine."""
+
+    risk_model: str = "risk-neutral"
+    version: str = "1.0.0"
+
+    def price(
+        self,
+        *,
+        spot: float,
+        strike: float,
+        volatility: float,
+        rate: float,
+        time_to_expiry: float,
+        option_type: str = "call",
+    ) -> float:
+        if time_to_expiry <= 0:
+            intrinsic = max(0.0, spot - strike) if option_type == "call" else max(0.0, strike - spot)
+            return intrinsic
+
+        if volatility <= 0:
+            discounted_strike = strike * math.exp(-rate * time_to_expiry)
+            if option_type == "call":
+                return max(0.0, spot - discounted_strike)
+            if option_type == "put":
+                return max(0.0, discounted_strike - spot)
+            raise ValueError(f"Unsupported option type: {option_type}")
+
+        if option_type not in {"call", "put"}:
+            raise ValueError(f"Unsupported option type: {option_type}")
+
+        sqrt_t = math.sqrt(time_to_expiry)
+        d1 = (
+            math.log(spot / strike) + (rate + 0.5 * volatility**2) * time_to_expiry
+        ) / (volatility * sqrt_t)
+        d2 = d1 - volatility * sqrt_t
+
+        if option_type == "call":
+            price = spot * _norm_cdf(d1) - strike * math.exp(-rate * time_to_expiry) * _norm_cdf(d2)
+        else:
+            price = strike * math.exp(-rate * time_to_expiry) * _norm_cdf(-d2) - spot * _norm_cdf(-d1)
+
+        return price
+
+    def metadata(self) -> Dict[str, str]:
+        return {
+            "name": "Black-Scholes",
+            "version": self.version,
+            "riskModel": self.risk_model,
+            "assumptions": "log-normal asset returns, continuous hedging",
+        }
+
+
+def _norm_cdf(x: float) -> float:
+    """Cumulative distribution function for the standard normal distribution."""
+
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))


### PR DESCRIPTION
## Summary
- implement a simplified Black-Scholes pricing engine and orchestrator with dependency injection support
- expose pricing model metadata from the gateway quote binding for downstream consumers
- add pytest coverage that exercises the orchestrator and gateway behaviour

## Testing
- pytest services/pricing-orchestrator/tests/test_orchestrator.py

------
https://chatgpt.com/codex/tasks/task_e_68ce60460ef8832ca471f5e4883afb0e