### PR TITLE
Implement FX portal env scaffolding and UI kit baseline

### DIFF
--- a/apps/portal-web/.env.local.example
+++ b/apps/portal-web/.env.local.example
@@ -5,6 +5,16 @@ NEXTAUTH_URL=http://localhost:3000
 # Credentials provider seed user
 PORTAL_DEMO_USERNAME=demo@fxportal.local
 PORTAL_DEMO_PASSWORD=demo-pass
+PORTAL_AUTH_DEMO_MODE=true
 
-# FastAPI gateway base URL
+# FastAPI gateway configuration
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+PORTAL_GATEWAY_API_KEY=local-dev-token
+
+# Audit service integration
+PORTAL_AUDIT_BASE_URL=http://localhost:8001
+PORTAL_AUDIT_API_KEY=local-audit-key
+
+# Telemetry instrumentation
+NEXT_PUBLIC_OTEL_COLLECTOR_URL=http://localhost:4318
+NEXT_PUBLIC_OTEL_SERVICE_NAME=fx-portal-web

--- a/apps/portal-web/.eslintrc.json
+++ b/apps/portal-web/.eslintrc.json
@@ -1,3 +1,24 @@
 {
-  "extends": ["next", "next/core-web-vitals"]
+  "extends": ["next", "next/core-web-vitals"],
+  "overrides": [
+    {
+      "files": ["app/api/**/*.{ts,tsx}"],
+      "env": {
+        "node": true
+      }
+    },
+    {
+      "files": ["app/**/*.{ts,tsx}", "components/**/*.{ts,tsx}", "lib/**/*.{ts,tsx}"],
+      "excludedFiles": ["app/api/**/*.{ts,tsx}"],
+      "rules": {
+        "no-restricted-syntax": [
+          "error",
+          {
+            "selector": "MemberExpression[object.type='MemberExpression'][object.object.name='process'][object.property.name='env'][property.name='NEXT_PUBLIC_API_BASE_URL']",
+            "message": "Use the Next.js API proxy route instead of referencing NEXT_PUBLIC_API_BASE_URL directly."
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/apps/portal-web/app/api/_lib/gateway-proxy.ts
+++ b/apps/portal-web/app/api/_lib/gateway-proxy.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const GATEWAY_BASE_URL = (process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000").replace(/\/$/, "");
+const GATEWAY_API_KEY = process.env.PORTAL_GATEWAY_API_KEY;
+
+function buildTargetUrl(path: string): string {
+  if (!path.startsWith("/")) {
+    return `${GATEWAY_BASE_URL}/${path}`;
+  }
+  return `${GATEWAY_BASE_URL}${path}`;
+}
+
+async function readRequestBody(request: NextRequest): Promise<string | undefined> {
+  if (request.method === "GET" || request.method === "HEAD") {
+    return undefined;
+  }
+
+  const clone = request.clone();
+  const text = await clone.text();
+  return text.length > 0 ? text : undefined;
+}
+
+export async function proxyGatewayJSON(request: NextRequest, path: string): Promise<NextResponse> {
+  try {
+    const body = await readRequestBody(request);
+    const upstream = await fetch(buildTargetUrl(path), {
+      method: request.method,
+      headers: {
+        "Content-Type": request.headers.get("content-type") ?? "application/json",
+        ...(GATEWAY_API_KEY ? { "X-API-Key": GATEWAY_API_KEY } : {}),
+      },
+      body,
+      cache: "no-store",
+    });
+
+    const contentType = upstream.headers.get("content-type") ?? "application/json";
+    const text = await upstream.text();
+
+    if (!contentType.includes("application/json")) {
+      return new NextResponse(text, {
+        status: upstream.status,
+        headers: { "Content-Type": contentType },
+      });
+    }
+
+    const json = text ? JSON.parse(text) : {};
+    return NextResponse.json(json, { status: upstream.status });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Gateway request failed";
+    return NextResponse.json(
+      {
+        error: "gateway_proxy_error",
+        message,
+      },
+      { status: 502 }
+    );
+  }
+}

--- a/apps/portal-web/app/api/execution/orders/route.ts
+++ b/apps/portal-web/app/api/execution/orders/route.ts
@@ -1,0 +1,6 @@
+import type { NextRequest } from "next/server";
+import { proxyGatewayJSON } from "../../_lib/gateway-proxy";
+
+export async function POST(request: NextRequest) {
+  return proxyGatewayJSON(request, "/api/execution/orders");
+}

--- a/apps/portal-web/app/api/quotes/binding/route.ts
+++ b/apps/portal-web/app/api/quotes/binding/route.ts
@@ -1,0 +1,6 @@
+import type { NextRequest } from "next/server";
+import { proxyGatewayJSON } from "../../_lib/gateway-proxy";
+
+export async function POST(request: NextRequest) {
+  return proxyGatewayJSON(request, "/api/quotes/binding");
+}

--- a/apps/portal-web/app/api/risk/plan/route.ts
+++ b/apps/portal-web/app/api/risk/plan/route.ts
@@ -1,0 +1,6 @@
+import type { NextRequest } from "next/server";
+import { proxyGatewayJSON } from "../../_lib/gateway-proxy";
+
+export async function POST(request: NextRequest) {
+  return proxyGatewayJSON(request, "/api/risk/plan");
+}

--- a/apps/portal-web/lib/api.ts
+++ b/apps/portal-web/lib/api.ts
@@ -1,12 +1,11 @@
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8000';
-
 async function postJSON<T>(path: string, body: unknown): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${path}`, {
+  const response = await fetch(path, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify(body)
+    body: JSON.stringify(body),
+    cache: 'no-store'
   });
 
   if (!response.ok) {

--- a/packages/ui-kit/.eslintrc.cjs
+++ b/packages/ui-kit/.eslintrc.cjs
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const path = require('path');
+
+function resolveTypeScriptParser() {
+  const pnpmDir = path.join(__dirname, '..', 'node_modules', '.pnpm');
+  if (!fs.existsSync(pnpmDir)) {
+    const workspaceDir = path.join(__dirname, '..', '..', 'node_modules', '.pnpm');
+    if (!fs.existsSync(workspaceDir)) {
+      throw new Error('Unable to locate pnpm virtual store for @typescript-eslint/parser');
+    }
+    return locateParser(workspaceDir);
+  }
+  return locateParser(pnpmDir);
+}
+
+function locateParser(baseDir) {
+  const entry = fs
+    .readdirSync(baseDir)
+    .filter((name) => name.startsWith('@typescript-eslint+parser@'))
+    .sort()
+    .pop();
+  if (!entry) {
+    throw new Error('Unable to resolve @typescript-eslint/parser from workspace.');
+  }
+  const parserDir = path.join(baseDir, entry, 'node_modules', '@typescript-eslint', 'parser');
+  return require.resolve('@typescript-eslint/parser', { paths: [parserDir] });
+}
+
+const parserPath = resolveTypeScriptParser();
+
+module.exports = {
+  root: true,
+  parser: parserPath,
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true
+    }
+  },
+  plugins: ['react'],
+  extends: ['eslint:recommended', 'plugin:react/recommended', 'prettier'],
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
+  ignorePatterns: ['dist', 'node_modules'],
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    'no-undef': 'off',
+    'no-unused-vars': 'off'
+  }
+};

--- a/packages/ui-kit/src/components/portal/PortalExposureCard.tsx
+++ b/packages/ui-kit/src/components/portal/PortalExposureCard.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+import {
+  portalPolicyStatusBadge,
+  portalPolicyStatusCopy,
+  portalTheme,
+  type PortalPolicyStatus
+} from './theme';
+
+function clampPercent(value: number): number {
+  if (Number.isNaN(value)) {
+    return 0;
+  }
+  return Math.min(100, Math.max(0, value));
+}
+
+function formatPercent(value: number): string {
+  const normalized = clampPercent(value);
+  if (Number.isInteger(normalized)) {
+    return `${normalized.toFixed(0)}%`;
+  }
+  return `${normalized.toFixed(1)}%`;
+}
+
+function formatUpdatedLabel(updatedAt: string, override?: string): string {
+  if (override) {
+    return override;
+  }
+  const date = new Date(updatedAt);
+  if (Number.isNaN(date.getTime())) {
+    return updatedAt;
+  }
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+}
+
+export interface PortalExposureCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  currencyPair: string;
+  netExposure: string;
+  hedgedPercent: number;
+  policyStatus: PortalPolicyStatus;
+  updatedAt: string;
+  updatedLabel?: string;
+}
+
+export const PortalExposureCard = React.forwardRef<HTMLDivElement, PortalExposureCardProps>(
+  (
+    { currencyPair, netExposure, hedgedPercent, policyStatus, updatedAt, updatedLabel, className, ...props },
+    ref
+  ) => {
+    const normalized = clampPercent(hedgedPercent);
+    const percentLabel = formatPercent(normalized);
+    const timestampLabel = formatUpdatedLabel(updatedAt, updatedLabel);
+
+    return (
+      <div ref={ref} className={cn(portalTheme.containers.card, className)} {...props}>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className={portalTheme.text.label}>Currency Pair</p>
+            <p className={portalTheme.text.heading}>{currencyPair}</p>
+          </div>
+          <span className={portalPolicyStatusBadge(policyStatus)}>{portalPolicyStatusCopy[policyStatus]}</span>
+        </div>
+
+        <div className="flex flex-wrap items-end justify-between gap-6">
+          <div>
+            <p className={portalTheme.text.label}>Net Exposure</p>
+            <p className={cn(portalTheme.text.metric, portalTheme.metrics.emphasis)}>{netExposure}</p>
+          </div>
+          <div className="text-right">
+            <p className={portalTheme.text.label}>Hedged</p>
+            <p className={cn(portalTheme.text.heading, portalTheme.metrics.neutral)}>{percentLabel}</p>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <div
+            className={portalTheme.progress.track}
+            role="progressbar"
+            aria-label="Hedged percentage"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={Math.round(normalized)}
+          >
+            <div
+              className={portalTheme.progress.indicator}
+              style={{ width: `${normalized}%` }}
+              aria-hidden="true"
+            />
+          </div>
+          <p className={portalTheme.text.helper}>Updated {timestampLabel}</p>
+        </div>
+      </div>
+    );
+  }
+);
+
+PortalExposureCard.displayName = 'PortalExposureCard';

--- a/packages/ui-kit/src/components/portal/PortalHedgePlaybookCard.tsx
+++ b/packages/ui-kit/src/components/portal/PortalHedgePlaybookCard.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+import { portalAlertsBadge, portalTheme } from './theme';
+
+function clampPercent(value: number): number {
+  if (Number.isNaN(value)) {
+    return 0;
+  }
+  return Math.min(100, Math.max(0, value));
+}
+
+function formatPercent(value: number): string {
+  const normalized = clampPercent(value);
+  if (Number.isInteger(normalized)) {
+    return `${normalized.toFixed(0)}%`;
+  }
+  return `${normalized.toFixed(1)}%`;
+}
+
+function formatDateLabel(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return timestamp;
+  }
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+}
+
+function driftTone(drift: number): string {
+  if (drift > 0.5) {
+    return portalTheme.metrics.negative;
+  }
+  if (drift < -0.5) {
+    return portalTheme.metrics.emphasis;
+  }
+  return portalTheme.metrics.neutral;
+}
+
+function driftLabel(drift: number): string {
+  const rounded = Math.round(drift * 10) / 10;
+  const prefix = rounded > 0 ? '+' : '';
+  return `${prefix}${rounded.toFixed(Math.abs(rounded % 1) > 0 ? 1 : 0)}% drift`;
+}
+
+export interface PortalHedgePlaybookCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  title: string;
+  description: string;
+  coverage: number;
+  drift: number;
+  alerts: number;
+  nextAction: string;
+  nextActionLabel?: string;
+}
+
+export const PortalHedgePlaybookCard = React.forwardRef<HTMLDivElement, PortalHedgePlaybookCardProps>(
+  ({ title, description, coverage, drift, alerts, nextAction, nextActionLabel, className, ...props }, ref) => {
+    const normalizedCoverage = clampPercent(coverage);
+    const coverageLabel = formatPercent(normalizedCoverage);
+    const actionLabel = nextActionLabel ?? formatDateLabel(nextAction);
+
+    return (
+      <div ref={ref} className={cn(portalTheme.containers.card, className)} {...props}>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className={portalTheme.text.label}>Playbook</p>
+            <p className={portalTheme.text.heading}>{title}</p>
+            <p className={cn('mt-2 text-sm leading-relaxed text-muted/90')}>{description}</p>
+          </div>
+          {alerts > 0 ? (
+            <span className={portalAlertsBadge(alerts)}>{alerts} Alert{alerts === 1 ? '' : 's'}</span>
+          ) : (
+            <span className={portalAlertsBadge(0)}>No Alerts</span>
+          )}
+        </div>
+
+        <div className={cn(portalTheme.containers.surface, 'flex flex-wrap items-center justify-between gap-4')}> 
+          <div>
+            <p className={portalTheme.text.label}>Coverage</p>
+            <p className={cn(portalTheme.text.metric, portalTheme.metrics.emphasis)}>{coverageLabel}</p>
+          </div>
+          <div className="text-right">
+            <p className={portalTheme.text.label}>Drift</p>
+            <p className={cn('text-lg font-semibold', driftTone(drift))}>{driftLabel(drift)}</p>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <div
+            className={portalTheme.progress.track}
+            role="progressbar"
+            aria-label="Coverage progress"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={Math.round(normalizedCoverage)}
+          >
+            <div
+              className={portalTheme.progress.indicator}
+              style={{ width: `${normalizedCoverage}%` }}
+              aria-hidden="true"
+            />
+          </div>
+          <p className={portalTheme.text.helper}>Next action {actionLabel}</p>
+        </div>
+      </div>
+    );
+  }
+);
+
+PortalHedgePlaybookCard.displayName = 'PortalHedgePlaybookCard';

--- a/packages/ui-kit/src/components/portal/PortalQuoteList.tsx
+++ b/packages/ui-kit/src/components/portal/PortalQuoteList.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+import { portalTheme } from './theme';
+
+function formatRate(value: number): string {
+  if (Number.isNaN(value)) {
+    return '—';
+  }
+  return value.toFixed(4);
+}
+
+function formatSpread(spreadBps: number): string {
+  if (Number.isNaN(spreadBps)) {
+    return '—';
+  }
+  return `${spreadBps.toFixed(1)} bps`;
+}
+
+function formatValidUntil(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return timestamp;
+  }
+  return date.toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+}
+
+export interface PortalQuoteListItem {
+  dealer: string;
+  midRate: number;
+  spreadBps: number;
+  validUntil: string;
+  best?: boolean;
+}
+
+export interface PortalQuoteListProps extends React.HTMLAttributes<HTMLDivElement> {
+  currencyPair: string;
+  offers: PortalQuoteListItem[];
+  emptyState?: React.ReactNode;
+}
+
+export const PortalQuoteList = React.forwardRef<HTMLDivElement, PortalQuoteListProps>(
+  ({ currencyPair, offers, emptyState, className, ...props }, ref) => {
+    if (!offers.length) {
+      return (
+        <div ref={ref} className={cn(portalTheme.containers.card, className)} {...props}>
+          <div className="flex items-start justify-between">
+            <div>
+              <p className={portalTheme.text.label}>Quotes</p>
+              <p className={portalTheme.text.heading}>{currencyPair}</p>
+            </div>
+          </div>
+          <div className={cn(portalTheme.containers.surface, 'text-center text-sm text-muted')}>
+            {emptyState ?? 'No dealer quotes available. Retry shortly.'}
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div ref={ref} className={cn(portalTheme.containers.card, className)} {...props}>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className={portalTheme.text.label}>Quotes</p>
+            <p className={portalTheme.text.heading}>{currencyPair}</p>
+          </div>
+          <span className={cn(portalTheme.badges.base, portalTheme.badges.covered)}>
+            Book Depth {offers.length}
+          </span>
+        </div>
+
+        <ul className="flex flex-col gap-3">
+          {offers.map((offer) => (
+            <li
+              key={`${offer.dealer}-${offer.validUntil}`}
+              className={cn(
+                portalTheme.containers.surface,
+                'flex items-center justify-between gap-4 border-white/10 bg-white/5',
+                offer.best && 'border-accent bg-accent/10 shadow-glow'
+              )}
+            >
+              <div className="flex flex-1 items-center gap-4">
+                <div className="flex min-w-[120px] flex-col">
+                  <span className={portalTheme.text.label}>Dealer</span>
+                  <span className="text-sm font-semibold text-text">{offer.dealer}</span>
+                </div>
+                <div className="flex min-w-[110px] flex-col">
+                  <span className={portalTheme.text.label}>Mid</span>
+                  <span className="text-lg font-semibold text-text">{formatRate(offer.midRate)}</span>
+                </div>
+                <div className="flex min-w-[110px] flex-col">
+                  <span className={portalTheme.text.label}>Spread</span>
+                  <span className="text-sm font-semibold text-muted">{formatSpread(offer.spreadBps)}</span>
+                </div>
+              </div>
+              <div className="flex flex-col items-end text-right">
+                {offer.best ? (
+                  <span className={cn(portalTheme.badges.base, portalTheme.badges.bestQuote)}>Best Quote</span>
+                ) : null}
+                <span className={portalTheme.text.helper}>Valid {formatValidUntil(offer.validUntil)}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+);
+
+PortalQuoteList.displayName = 'PortalQuoteList';

--- a/packages/ui-kit/src/components/portal/index.ts
+++ b/packages/ui-kit/src/components/portal/index.ts
@@ -1,0 +1,4 @@
+export * from './theme';
+export * from './PortalExposureCard';
+export * from './PortalQuoteList';
+export * from './PortalHedgePlaybookCard';

--- a/packages/ui-kit/src/components/portal/theme.ts
+++ b/packages/ui-kit/src/components/portal/theme.ts
@@ -1,0 +1,50 @@
+export type PortalPolicyStatus = 'covered' | 'warning' | 'critical';
+
+export const portalTheme = {
+  containers: {
+    card: 'glass-card relative flex flex-col gap-5 rounded-3xl border border-white/10 bg-white/10 p-6 text-text shadow-soft backdrop-blur-2xl',
+    surface: 'rounded-2xl border border-white/5 bg-white/5 p-4 backdrop-blur-xl'
+  },
+  text: {
+    label: 'text-xs font-semibold uppercase tracking-wider text-muted',
+    heading: 'text-xl font-semibold text-text',
+    metric: 'text-3xl font-semibold text-text',
+    helper: 'text-xs text-muted/90'
+  },
+  badges: {
+    base: 'inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-widest',
+    covered: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-300',
+    warning: 'border-amber-400/40 bg-amber-500/10 text-amber-200',
+    critical: 'border-rose-400/40 bg-rose-500/10 text-rose-200',
+    bestQuote: 'border-accent bg-accent/15 text-accent'
+  },
+  metrics: {
+    emphasis: 'text-accent',
+    neutral: 'text-muted',
+    negative: 'text-danger'
+  },
+  progress: {
+    track: 'h-2 w-full overflow-hidden rounded-full bg-white/10',
+    indicator: 'h-full rounded-full bg-accent shadow-glow'
+  }
+} as const;
+
+export const portalPolicyStatusCopy: Record<PortalPolicyStatus, string> = {
+  covered: 'Covered',
+  warning: 'Policy Warning',
+  critical: 'Policy Breach'
+};
+
+export function portalPolicyStatusBadge(status: PortalPolicyStatus): string {
+  return [portalTheme.badges.base, portalTheme.badges[status]].join(' ');
+}
+
+export function portalAlertsBadge(alerts: number): string {
+  if (alerts <= 0) {
+    return [portalTheme.badges.base, portalTheme.badges.covered].join(' ');
+  }
+  if (alerts > 2) {
+    return [portalTheme.badges.base, portalTheme.badges.critical].join(' ');
+  }
+  return [portalTheme.badges.base, portalTheme.badges.warning].join(' ');
+}

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -9,4 +9,5 @@ export * from './components/Stat';
 export * from './components/Table';
 export * from './components/TestimonialStrip';
 export * from './components/Toast';
+export * from './components/portal';
 export * from './styles';

--- a/packages/ui-kit/src/stories/portal/PortalExposureCard.stories.tsx
+++ b/packages/ui-kit/src/stories/portal/PortalExposureCard.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { PortalExposureCard, type PortalPolicyStatus } from '../../components/portal';
+
+const meta: Meta<typeof PortalExposureCard> = {
+  title: 'Portal/ExposureCard',
+  component: PortalExposureCard,
+  args: {
+    currencyPair: 'EUR / USD',
+    netExposure: '$4.8M',
+    hedgedPercent: 72,
+    policyStatus: 'covered' satisfies PortalPolicyStatus,
+    updatedAt: new Date().toISOString()
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PortalExposureCard>;
+
+export const Covered: Story = {};
+
+export const Warning: Story = {
+  args: {
+    policyStatus: 'warning',
+    hedgedPercent: 62,
+    updatedLabel: '5 minutes ago'
+  }
+};
+
+export const Critical: Story = {
+  args: {
+    policyStatus: 'critical',
+    hedgedPercent: 38,
+    netExposure: '$9.1M',
+    updatedLabel: '15 minutes ago'
+  }
+};

--- a/packages/ui-kit/src/stories/portal/PortalHedgePlaybookCard.stories.tsx
+++ b/packages/ui-kit/src/stories/portal/PortalHedgePlaybookCard.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { PortalHedgePlaybookCard } from '../../components/portal/PortalHedgePlaybookCard';
+
+const meta: Meta<typeof PortalHedgePlaybookCard> = {
+  title: 'Portal/HedgePlaybookCard',
+  component: PortalHedgePlaybookCard,
+  args: {
+    title: 'Asia Pacific Quarterly Ladder',
+    description: 'Executes 6 tranches against APAC exposures with VaR guardrails and alerts for threshold breaches.',
+    coverage: 68,
+    drift: -1.8,
+    alerts: 1,
+    nextAction: new Date(Date.now() + 3600 * 1000).toISOString()
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PortalHedgePlaybookCard>;
+
+export const Default: Story = {};
+
+export const Healthy: Story = {
+  args: {
+    coverage: 82,
+    drift: 0.2,
+    alerts: 0,
+    nextActionLabel: 'Execution window closes in 2 hours'
+  }
+};
+
+export const Escalated: Story = {
+  args: {
+    coverage: 47,
+    drift: 3.6,
+    alerts: 4,
+    nextActionLabel: 'Awaiting compliance sign-off'
+  }
+};

--- a/packages/ui-kit/src/stories/portal/PortalQuoteList.stories.tsx
+++ b/packages/ui-kit/src/stories/portal/PortalQuoteList.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import {
+  PortalQuoteList,
+  type PortalQuoteListProps
+} from '../../components/portal/PortalQuoteList';
+
+const meta: Meta<typeof PortalQuoteList> = {
+  title: 'Portal/QuoteList',
+  component: PortalQuoteList,
+  args: {
+    currencyPair: 'GBP / SGD',
+    offers: [
+      {
+        dealer: 'Dealer Alpha',
+        midRate: 1.8123,
+        spreadBps: 12.4,
+        validUntil: new Date(Date.now() + 60 * 1000).toISOString(),
+        best: true
+      },
+      {
+        dealer: 'Dealer Bravo',
+        midRate: 1.8129,
+        spreadBps: 14.2,
+        validUntil: new Date(Date.now() + 90 * 1000).toISOString()
+      },
+      {
+        dealer: 'Dealer Charlie',
+        midRate: 1.8135,
+        spreadBps: 18.6,
+        validUntil: new Date(Date.now() + 120 * 1000).toISOString()
+      }
+    ] satisfies PortalQuoteListProps['offers']
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PortalQuoteList>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: {
+    offers: [],
+    emptyState: 'Start a quote request to populate dealer responses.'
+  }
+};

--- a/packages/ui-kit/tsconfig.json
+++ b/packages/ui-kit/tsconfig.json
@@ -11,8 +11,7 @@
     "declaration": true,
     "outDir": "dist",
     "baseUrl": "./src",
-    "resolveJsonModule": true,
-    "types": ["node"]
+    "resolveJsonModule": true
   },
   "include": ["src"],
   "exclude": ["dist", "node_modules"]

--- a/specs/001-make-the-fx/quickstart.md
+++ b/specs/001-make-the-fx/quickstart.md
@@ -6,6 +6,20 @@
 - FastAPI gateway running locally: `uvicorn services.gateway.app:app --reload` (dry-run mode default).
 - `.env.local` files populated for portal/admin (NextAuth secrets, API base URL).
 
+## Environment Variables
+Populate `apps/portal-web/.env.local` using the example file. Required keys:
+
+- `NEXTAUTH_SECRET` – random string used to encrypt NextAuth JWT/session data.
+- `NEXTAUTH_URL` – public URL of the portal instance (defaults to `http://localhost:3000`).
+- `PORTAL_DEMO_USERNAME` / `PORTAL_DEMO_PASSWORD` – seeded credential pair for the credentials provider.
+- `PORTAL_AUTH_DEMO_MODE` – set to `true` to enable demo sign-in bypass for local testing.
+- `NEXT_PUBLIC_API_BASE_URL` – FastAPI gateway base URL consumed by route handlers and React Query.
+- `PORTAL_GATEWAY_API_KEY` – bearer token forwarded from Next.js route handlers to the gateway.
+- `PORTAL_AUDIT_BASE_URL` – audit service base URL used for compliance logging hooks.
+- `PORTAL_AUDIT_API_KEY` – secret used to authenticate audit log submissions.
+- `NEXT_PUBLIC_OTEL_COLLECTOR_URL` – OTLP/HTTP collector endpoint for OpenTelemetry browser exports.
+- `NEXT_PUBLIC_OTEL_SERVICE_NAME` – logical service name used in telemetry payloads.
+
 ## Setup
 1. Install JS deps: `pnpm install`.
 2. Install Python deps: `python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt`.


### PR DESCRIPTION
## Summary
- add portal environment variable examples and document configuration in the quickstart (T001)
- scaffold API proxy route handlers with lint guardrails for the portal app (T002)
- introduce portal UI kit theme components and Storybook coverage (T003)

## Testing
- pnpm --filter portal-web lint
- pnpm --filter ui-kit lint
- pnpm --filter ui-kit build

------
https://chatgpt.com/codex/tasks/task_e_68cf76d446c8832c92ad0985acee5aba