### PR TITLE
T001: scaffold shared API client alias

### DIFF
--- a/apps/admin/lib/api/__tests__/shared-client.type-test.ts
+++ b/apps/admin/lib/api/__tests__/shared-client.type-test.ts
@@ -1,0 +1,11 @@
+import { createGatewayClient } from '@shared/api';
+
+const client = createGatewayClient({
+  baseUrl: 'http://localhost:8000',
+  pollIntervalMs: 10_000,
+  maxBackoffMs: 60_000,
+  maxRetries: 3,
+  backoffJitter: 0.2,
+});
+
+void client;

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "tsc --project tsconfig.test.json"
   },
   "dependencies": {
     "next": "14.2.3",

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -24,6 +24,12 @@
     "paths": {
       "@/*": [
         "./*"
+      ],
+      "@shared/api": [
+        "../shared/api/index"
+      ],
+      "@shared/api/*": [
+        "../shared/api/*"
       ]
     },
     "plugins": [

--- a/apps/admin/tsconfig.test.json
+++ b/apps/admin/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  },
+  "include": [
+    "lib/api/__tests__/**/*.ts"
+  ]
+}

--- a/apps/portal-web/lib/api/__tests__/shared-client.type-test.ts
+++ b/apps/portal-web/lib/api/__tests__/shared-client.type-test.ts
@@ -1,0 +1,11 @@
+import { createGatewayClient } from '@shared/api';
+
+const client = createGatewayClient({
+  baseUrl: 'http://localhost:8000',
+  pollIntervalMs: 10_000,
+  maxBackoffMs: 60_000,
+  maxRetries: 3,
+  backoffJitter: 0.2,
+});
+
+void client;

--- a/apps/portal-web/package.json
+++ b/apps/portal-web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "tsc --project tsconfig.test.json"
   },
   "dependencies": {
     "classnames": "^2.3.2",

--- a/apps/portal-web/tsconfig.json
+++ b/apps/portal-web/tsconfig.json
@@ -29,6 +29,12 @@
       "@/styles/*": [
         "./app/*"
       ],
+      "@shared/api": [
+        "../shared/api/index"
+      ],
+      "@shared/api/*": [
+        "../shared/api/*"
+      ],
       "ui-kit": [
         "../../packages/ui-kit/dist"
       ],

--- a/apps/portal-web/tsconfig.test.json
+++ b/apps/portal-web/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false
+  },
+  "include": [
+    "lib/api/__tests__/**/*.ts"
+  ]
+}

--- a/apps/shared/api/client.ts
+++ b/apps/shared/api/client.ts
@@ -1,0 +1,81 @@
+/**
+ * Placeholder gateway client shared between the portal and admin applications.
+ *
+ * Environment variables recognised by this client:
+ * - `NEXT_PUBLIC_GATEWAY_POLL_INTERVAL_MS`: default polling cadence in milliseconds.
+ * - `NEXT_PUBLIC_GATEWAY_MAX_BACKOFF_MS`: upper bound for exponential backoff.
+ * - `NEXT_PUBLIC_GATEWAY_MAX_RETRIES`: limit for consecutive retry attempts before surfacing an outage.
+ * - `NEXT_PUBLIC_GATEWAY_BACKOFF_JITTER`: optional jitter coefficient (0-1) applied to retries.
+ */
+export interface GatewayClientOptions {
+  /** Fully qualified URL to the FastAPI gateway (e.g. http://localhost:8000). */
+  baseUrl: string;
+  /** Polling cadence override in milliseconds. */
+  pollIntervalMs?: number;
+  /** Maximum backoff delay override in milliseconds. */
+  maxBackoffMs?: number;
+  /** Maximum retry attempts override. */
+  maxRetries?: number;
+  /** Backoff jitter multiplier override (0-1). */
+  backoffJitter?: number;
+}
+
+export interface GatewayClientConfig {
+  baseUrl: string;
+  pollIntervalMs: number;
+  maxBackoffMs: number;
+  maxRetries: number;
+  backoffJitter: number;
+}
+
+export interface GatewayClientPlaceholder {
+  /** Returns the resolved runtime configuration for polling/backoff. */
+  getConfig(): GatewayClientConfig;
+}
+
+export const GATEWAY_CLIENT_ENV = {
+  pollIntervalMs: 'NEXT_PUBLIC_GATEWAY_POLL_INTERVAL_MS',
+  maxBackoffMs: 'NEXT_PUBLIC_GATEWAY_MAX_BACKOFF_MS',
+  maxRetries: 'NEXT_PUBLIC_GATEWAY_MAX_RETRIES',
+  backoffJitter: 'NEXT_PUBLIC_GATEWAY_BACKOFF_JITTER',
+} as const;
+
+const DEFAULT_CONFIG: Omit<GatewayClientConfig, 'baseUrl'> = {
+  pollIntervalMs: 10_000,
+  maxBackoffMs: 60_000,
+  maxRetries: 3,
+  backoffJitter: 0.2,
+};
+
+function readNumberFromEnv(key: string, fallback: number): number {
+  const raw = process.env[key];
+  if (!raw) {
+    return fallback;
+  }
+
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function resolveConfig(options: GatewayClientOptions): GatewayClientConfig {
+  const pollIntervalMs = options.pollIntervalMs ?? readNumberFromEnv(GATEWAY_CLIENT_ENV.pollIntervalMs, DEFAULT_CONFIG.pollIntervalMs);
+  const maxBackoffMs = options.maxBackoffMs ?? readNumberFromEnv(GATEWAY_CLIENT_ENV.maxBackoffMs, DEFAULT_CONFIG.maxBackoffMs);
+  const maxRetries = options.maxRetries ?? readNumberFromEnv(GATEWAY_CLIENT_ENV.maxRetries, DEFAULT_CONFIG.maxRetries);
+  const backoffJitter = options.backoffJitter ?? readNumberFromEnv(GATEWAY_CLIENT_ENV.backoffJitter, DEFAULT_CONFIG.backoffJitter);
+
+  return {
+    baseUrl: options.baseUrl,
+    pollIntervalMs,
+    maxBackoffMs,
+    maxRetries,
+    backoffJitter,
+  };
+}
+
+export function createGatewayClient(options: GatewayClientOptions): GatewayClientPlaceholder {
+  const config = resolveConfig(options);
+
+  return {
+    getConfig: () => config,
+  };
+}

--- a/apps/shared/api/index.ts
+++ b/apps/shared/api/index.ts
@@ -1,0 +1,1 @@
+export * from './client';

--- a/specs/002-wire-portal-and/research.md
+++ b/specs/002-wire-portal-and/research.md
@@ -9,6 +9,7 @@
 
 ### Polling cadence & backoff
 - **Decision**: Default to 10s polling for exposures and quotes, adjustable via env; use exponential backoff (up to 60s) on errors with jitter, abort after 3 consecutive failures and surface alert.
+- **Implementation Notes**: Shared client resolves polling/backoff config from `NEXT_PUBLIC_GATEWAY_POLL_INTERVAL_MS`, `NEXT_PUBLIC_GATEWAY_MAX_BACKOFF_MS`, `NEXT_PUBLIC_GATEWAY_MAX_RETRIES`, and `NEXT_PUBLIC_GATEWAY_BACKOFF_JITTER` (with safe fallbacks when unset).
 - **Rationale**: Balances real-time feel with gateway SLA (<200ms p95, limited load).
 - **Alternatives**: WebSockets (overhead, not yet supported), manual refresh (poor UX).
 


### PR DESCRIPTION
## Summary
- add a shared TypeScript alias for `@shared/api` in the portal and admin workspaces with lightweight compilation smoke tests
- scaffold a placeholder gateway client that resolves polling/backoff configuration from documented environment variables
- capture the resolved environment variable names in the research log for the feature

## Testing
- pnpm --filter portal-web test
- pnpm --filter admin test
- PYTHONPATH=. pytest services/gateway/tests
- pnpm --filter ui-kit test *(fails: Storybook CLI in this workspace rejects the `--watch` flag)*
- pnpm --filter ui-kit exec test-storybook *(fails: Storybook server not running at 127.0.0.1:6006)*
- uvx --from git+https://github.com/github/spec-kit.git specify check *(fails: unable to resolve remote requirement in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf7855e654832c894ab375ba3910ee