### PR TITLE
T001: add shared auth helpers

### DIFF
--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -24,6 +24,12 @@
     "paths": {
       "@/*": [
         "./*"
+      ],
+      "@shared/auth": [
+        "../shared/auth"
+      ],
+      "@shared/auth/*": [
+        "../shared/auth/*"
       ]
     },
     "plugins": [

--- a/apps/portal-web/tsconfig.json
+++ b/apps/portal-web/tsconfig.json
@@ -29,6 +29,12 @@
       "@/styles/*": [
         "./app/*"
       ],
+      "@shared/auth": [
+        "../shared/auth"
+      ],
+      "@shared/auth/*": [
+        "../shared/auth/*"
+      ],
       "ui-kit": [
         "../../packages/ui-kit/dist"
       ],

--- a/apps/shared/auth/index.ts
+++ b/apps/shared/auth/index.ts
@@ -1,0 +1,114 @@
+export const APP_ROLES = [
+  "treasury_manager",
+  "risk_analyst",
+  "compliance_officer",
+  "admin",
+] as const;
+
+export type AppRole = (typeof APP_ROLES)[number];
+
+export const ROLE_LABELS: Record<AppRole, string> = {
+  treasury_manager: "Treasury Manager",
+  risk_analyst: "Risk Analyst",
+  compliance_officer: "Compliance Officer",
+  admin: "Administrator",
+};
+
+const MFA_REQUIRED_ROLES: AppRole[] = ["compliance_officer", "admin"];
+
+export interface SessionUserLike {
+  id?: string | null;
+  email?: string | null;
+  name?: string | null;
+  roles?: string[] | null;
+  mfaVerified?: boolean | null;
+}
+
+export interface SessionLike {
+  user?: SessionUserLike | null;
+  expires?: string | null;
+}
+
+export interface NormalizedSession {
+  userId: string;
+  email?: string;
+  name?: string;
+  roles: AppRole[];
+  mfaVerified: boolean;
+  expiresAt?: number;
+}
+
+const roleSet = new Set<AppRole>(APP_ROLES);
+
+export function normalizeRoles(roles: unknown): AppRole[] {
+  if (!Array.isArray(roles)) {
+    return [];
+  }
+
+  const filtered = roles.filter((role): role is AppRole => roleSet.has(role as AppRole));
+
+  return [...new Set(filtered)];
+}
+
+export function normalizeSession(session: SessionLike | null | undefined): NormalizedSession | null {
+  if (!session?.user?.id) {
+    return null;
+  }
+
+  const roles = normalizeRoles(session.user.roles ?? []);
+
+  return {
+    userId: session.user.id,
+    email: session.user.email ?? undefined,
+    name: session.user.name ?? undefined,
+    roles,
+    mfaVerified: Boolean(session.user.mfaVerified),
+    expiresAt: session.expires ? Date.parse(session.expires) : undefined,
+  };
+}
+
+export function hasRole(session: NormalizedSession | null, role: AppRole): boolean {
+  if (!session) {
+    return false;
+  }
+
+  return session.roles.includes(role);
+}
+
+export function hasAnyRole(session: NormalizedSession | null, roles: AppRole[]): boolean {
+  if (!session) {
+    return false;
+  }
+
+  return roles.some((role) => hasRole(session, role));
+}
+
+export function requiresMfa(role: AppRole): boolean {
+  return MFA_REQUIRED_ROLES.includes(role);
+}
+
+export function isMfaSatisfied(session: NormalizedSession | null): boolean {
+  if (!session) {
+    return false;
+  }
+
+  if (!session.roles.some((role) => requiresMfa(role))) {
+    return true;
+  }
+
+  return session.mfaVerified;
+}
+
+export function canAccess(session: NormalizedSession | null, requiredRoles: AppRole | AppRole[]): boolean {
+  if (!session) {
+    return false;
+  }
+
+  const rolesToCheck = Array.isArray(requiredRoles) ? requiredRoles : [requiredRoles];
+
+  if (rolesToCheck.length === 0) {
+    return true;
+  }
+
+  return rolesToCheck.every((role) => hasRole(session, role));
+}


### PR DESCRIPTION
## Summary
- create a shared auth workspace module with role constants, session normalization helpers, and MFA checks
- expose the shared auth module via TypeScript path aliases in the portal and admin apps for upcoming work

## Testing
- pnpm --filter portal-web test
- pnpm --filter admin test
- pnpm --filter ui-kit test *(fails: storybook test --watch unknown option)*
- pytest services/audit/tests *(fails: directory not found)*
- uvx --from git+https://github.com/github/spec-kit.git specify check *(fails: git operation to fetch spec-kit)*

------
https://chatgpt.com/codex/tasks/task_e_68cf79970658832cbf330074c2fd8899